### PR TITLE
Cache use in Nette 2.1

### DIFF
--- a/cs/caching.texy
+++ b/cs/caching.texy
@@ -71,13 +71,31 @@ $cache = new Cache($storage, 'HtmlOutput');
 Služba cacheStorage
 ========
 
-Abychom si nemuseli všude vytvářet nebo předávat objekt `$storage`, lze využít [systémový DI kontejner |configuring], který disponuje službou `cacheStorage` s výchozím úložištěm ukládajícím data do adresáře určeného parametrem `tempDir` resp. konstantou `TEMP_DIR`.
+Abychom si nemuseli všude vytvářet nebo předávat objekt `$storage`, lze využít [systémový DI kontejner |configuring], který disponuje službou `cacheStorage` s výchozím úložištěm. Použití v presenterech nebo komponentách je pak jednoduché a i díky autowiringu stačí cacheStorage přiřadit přes konstruktor následovně:
 
 /--php
-// $container je systémový kontejner
-$cache = new Cache($container->getService('cacheStorage'), 'htmlFront');
-$cache->save($key, $data);
+
+private $cacheStorage;
+
+public function __construct(IStorage $cacheStorage) {
+	parent::__construct();
+	$this->cacheStorage = $cacheStorage;
+}
+
 \--
+
+A v kódu pak:
+
+/--php
+
+// appCache jsme si zvolili jako jmenný prostor v rámci cache pro naší aplikaci
+$cache = new Cache($this->cacheStorage, 'appCache');
+$cache->save($key, $data);
+
+\--
+
+Možná se ptáte proč IStorage? Je to jednoduché - výchozí cacheStorage aplikace nemusí ukládat na disk jak je to v případě FileStorage, ale např. Redis nebo memcached, naše komponenta nebo presenter tedy zobne tu výchozí, která se používá skrz celou aplikaci a neřeší, kam a jak se zacachovaný výsledek uloží.
+
 
 
 Cachování v šablonách

--- a/cs/caching.texy
+++ b/cs/caching.texy
@@ -75,9 +75,10 @@ Abychom si nemuseli všude vytvářet nebo předávat objekt `$storage`, lze vyu
 
 /--php
 
+/** @var Nette\Caching\IStorage */
 private $cacheStorage;
 
-public function __construct(IStorage $cacheStorage) {
+public function __construct(Nette\Caching\IStorage $cacheStorage) {
 	parent::__construct();
 	$this->cacheStorage = $cacheStorage;
 }
@@ -89,12 +90,12 @@ A v kódu pak:
 /--php
 
 // appCache jsme si zvolili jako jmenný prostor v rámci cache pro naší aplikaci
-$cache = new Cache($this->cacheStorage, 'appCache');
+$cache = new Nette\Caching\Cache($this->cacheStorage, 'appCache');
 $cache->save($key, $data);
 
 \--
 
-Možná se ptáte proč IStorage? Je to jednoduché - výchozí cacheStorage aplikace nemusí ukládat na disk jak je to v případě FileStorage, ale např. Redis nebo memcached, naše komponenta nebo presenter tedy zobne tu výchozí, která se používá skrz celou aplikaci a neřeší, kam a jak se zacachovaný výsledek uloží.
+Možná se ptáte proč IStorage? Je to jednoduché - výchozí cacheStorage aplikace nemusí ukládat na disk jak je to v případě FileStorage, ale např. do databáze Redis nebo memcached, naše komponenta nebo presenter tedy vezme tu výchozí, která se používá skrz celou aplikaci, a neřeší, kam a jak se cachovaný výsledek uloží.
 
 
 


### PR DESCRIPTION
Using cache without getting the cacheStorage like $container->getService() which is deprecated in Nette 2.1 