### PR TITLE
recommended place for registering helpers

### DIFF
--- a/en/templating.texy
+++ b/en/templating.texy
@@ -318,6 +318,27 @@ Latte simplifies the notation - helpers are denoted by the pipe sign, they can b
 <p>{$text|shortify:100}</p>
 \--
 
+When registering a large number of helpers, it is recommended to define a separate class and load them with a loader.
+[Default helpers |default helpers] are registered like this:
+
+/--php
+$template->registerHelperLoader('Nette\Templating\Helpers::loader');
+\--
+
+The usual place to register your helpers is in your BasePresenter or BaseControl, overriding createTemplate().
+/--php
+protected function createTemplate($class = NULL)
+{
+  $template = parent::createTemplate();
+
+  $template->registerHelper(...);
+  
+  // or
+  $template->registerHelperLoader(...);
+  
+  return $template;
+}
+\--
 
 
 Independent template usage
@@ -353,12 +374,6 @@ $template = new FileTemplate('template.latte'); // template file
 $template->firstName = 'John';
 $template->lastName = 'Doe';
 $template->render(); // renders the template
-\--
-
-We need to register the helpers if we want to use them in the template. [Default helpers |default helpers] are registered like this:
-
-/--php
-$template->registerHelperLoader('Nette\Templating\Helpers::loader');
 \--
 
 


### PR DESCRIPTION
+ moved registerHelperLoader() out of "Independent template usage" to "Helpers" above because it's not related to independent usage, and should be listed among ways to register helpers.