### PR TITLE
Howto for using mailer configuration

### DIFF
--- a/en/configuring.texy
+++ b/en/configuring.texy
@@ -200,6 +200,12 @@ nette:
 		timeout: ...
 \--
 
+In order to make use of this configuration, you cannot instantiate mailer manually. Use autowiring and inject by interface:
+/--php
+  /** @var \Nette\Mail\IMailer @inject */
+  public $mailer;
+\--
+
 
 Database
 ========


### PR DESCRIPTION
Now that we can no longer use $mail->send(), extra effort needs to be made to make use of mailer configuration in config.neon.