### PR TITLE
ajax: added caution about nette.ajax.js

### DIFF
--- a/cs/ajax.texy
+++ b/cs/ajax.texy
@@ -13,6 +13,9 @@ AJAXový požadavek lze detekovat metodou služby [zapouzdřující HTTP požada
 
 AJAXový požadavek se nijak neliší od klasického požadavku - je zavolán presenter s určitým view a parametry. Je také věcí presenteru, jak bude na něj reagovat: může použít vlastní rutinu, která vrátí nějaký fragment HTML kódu (HTML snippet), XML dokument, JSON objekt nebo kód v JavaScriptu.
 
+.[caution]
+**Upozornění:** Pro zprovoznění AJAXu v aplikaci je nutné nainstalovat knihovnu [nette.ajax.js | http://addons.nette.org/vojtech-dobes/nette-ajax-js] od Vojty Dobeše.
+
 Pro odesílání dat prohlížeči ve formátu JSON lze využít předpřipravený objekt `payload`:
 
 /--php

--- a/en/ajax.texy
+++ b/en/ajax.texy
@@ -7,9 +7,16 @@ Modern web applications nowadays run half on a server and half in a browser. AJA
 - passing variables between PHP and JavaScript
 - AJAX applications debugging
 \--
+
 An AJAX request can be detected using a method of a service [encapsulating a HTTP request | http-request-response#http-request] `$httpRequest->isAjax()` (detects based on the `X-Requested-With` HTTP header). There is also a shorthand method in presenter: `$this->isAjax()`.
+
 An AJAX request is no different from a normal one – a presenter is called with a certain view and parameters. It is, too, up to the presenter how will it react: it can use its routines to either return a fragment of HTML code (a snippet), an XML document, a JSON object or a piece of Javascript code.
+
+.[caution]
+**Caution:** To make AJAX work you need to include [nette.ajax.js | http://addons.nette.org/vojtech-dobes/nette-ajax-js] library by Vojtěch Dobeš.
+
 There is a pre-processed object called `payload` dedicated to sending data to the browser in JSON.
+
 /--php
 	public function actionDelete($id)
 	{


### PR DESCRIPTION
The tutorial is not fully functional as is, because it's missing JS implementation of client-side AJAX requests.
I have added caution and link to nette.ajax.js.