### PR TITLE
Homepage: added reference to CI and Debugger extensions

### DIFF
--- a/cs/homepage.texy
+++ b/cs/homepage.texy
@@ -53,7 +53,7 @@ Zde najdete celou řadu zdrojů, které vám pomohou naučit se Nette Framework 
 - [Komponenty a ovládací prvky | components]
 - [Routování URL | routing]
 - [Přihlašování & oprávnění uživatelů | access-control]
-- [Debugování a zpracování chyb | debugging] (ladění)
+- [Debugování a zpracování chyb | debugging] (ladění), [Rozšíření debuggeru | debugger-extensions]
 - [AJAX]
 - [Rozšíření PHP | PHP Language Enhancements] (Nette\Object, anotace, reflexe)
 - [HTTP request & response]
@@ -64,7 +64,7 @@ Zde najdete celou řadu zdrojů, které vám pomohou naučit se Nette Framework 
 - [Zpracování obrázků | images]
 - [Cache | Caching]
 - [Lokalizace | Localization]
-- [Testování | Testing]
+- [Testování | Testing], [Průběžná integrace | testing-with-travis]
 - [Stránkování | Pagination]
 - [Auto-loading tříd | Auto-loading]
 - [Vyhledávání souborů a adresářů | finder]

--- a/en/homepage.texy
+++ b/en/homepage.texy
@@ -52,7 +52,7 @@ Here you can find a lot of sources which can help you to learn Nette Framework a
 - [Components and Controls | components]
 - [Routing]
 - [User Authentication & Authorization | access-control]
-- [Debugging and Error Handling | debugging]
+- [Debugging and Error Handling | debugging], [Debugger extensions | debugger-extensions]
 - [AJAX]
 - [PHP Language Enhancements]<br>(Nette\Object, annotations & reflection)
 - [HTTP request & response]
@@ -63,7 +63,7 @@ Here you can find a lot of sources which can help you to learn Nette Framework a
 - [Image Manipulation | images]
 - [Caching]
 - [Localization]
-- [Testing]
+- [Testing], [Continuous integration | testing-with-travis]
 - [Pagination]
 - [Auto-loading]
 - [Browsing files on disk | finder]


### PR DESCRIPTION
Looks like I've forgotten to add links for Debugger extensions and CI to the `homepage`.