### PR TITLE
IfCurrent: moved from conditions to links

### DIFF
--- a/cs/default-macros.texy
+++ b/cs/default-macros.texy
@@ -20,18 +20,17 @@ Zajímají vás bližší informace o [syntaxi Latte |templating#latte] nebo o [
 | `{$cond ? $value1 : $value2}`|[ternární operátor |#Podmínky] |
 | `{$cond ? $value}`|[zkrácený "ternární" operátor |#Podmínky] |
 | `{ifset $var} … {elseifset $var} … {/ifset}`  [podmínka if (isset()) |#Podmínky] ||
-| `{ifCurrent $link} … {/ifCurrent}`  |[speciální případ {if} pro aktivní odkaz |#Podmínky]
 |---------------------------
 | Cykly ||
 |---------------------------
 | `{foreach $arr as $item} … {/foreach}` | [cyklus foreach |#Cykly]
 | `{for expr; expr; expr} … {/for}`      | [cyklus for |#Cykly]
-| `{while expr} … {/while}`      | [cyklus while |#Cykly]
-| `{continueIf $cond}`           | [podmíněný skok na další iteraci |#Cykly]
-| `{breakIf $cond}`              | [podmíněné ukončení cyklu |#Cykly]
-| `{first [$mod]} … {/first}`           | [vypsat při prvním průchodu |#Cykly]
-| `{last [$mod]} … {/last}`             | [vypsat při posledním průchodu |#Cykly]
-| `{sep} … {/sep}`               | [separátor |#Cykly]
+| `{while expr} … {/while}`              | [cyklus while |#Cykly]
+| `{continueIf $cond}`                   | [podmíněný skok na další iteraci |#Cykly]
+| `{breakIf $cond}`                      | [podmíněné ukončení cyklu |#Cykly]
+| `{first [$mod]} … {/first}`            | [vypsat při prvním průchodu |#Cykly]
+| `{last [$mod]} … {/last}`              | [vypsat při posledním průchodu |#Cykly]
+| `{sep} … {/sep}`                       | [separátor |#Cykly]
 |---------------------------
 | Proměnné ||
 |---------------------------
@@ -74,9 +73,10 @@ Zajímají vás bližší informace o [syntaxi Latte |templating#latte] nebo o [
 |---------------------------
 | Odkazy ||
 |---------------------------
-| `n:href`                       | "odkaz používaný v HTML elementech `<a>`":presenters#toc-odkazy-v-sablonach
-| `{link Presenter:action}`      | [vygeneruje odkaz |presenters#toc-odkazy-v-sablonach]
-| `{plink Presenter:action}`     | [vygeneruje odkaz na presenter |presenters#toc-odkazy-v-sablonach]
+| `n:href`                           | "odkaz používaný v HTML elementech `<a>`":presenters#toc-odkazy-v-sablonach
+| `{link Presenter:action}`          | [vygeneruje odkaz |presenters#toc-odkazy-v-sablonach]
+| `{plink Presenter:action}`         | [vygeneruje odkaz na presenter |presenters#toc-odkazy-v-sablonach]
+| `{ifCurrent $link} … {/ifCurrent}` | [vykoná příkazy uvnitř bloku, pokud je odkaz shodný s aktuální adresou |presenters#toc-odkazy-v-sablonach]
 |---------------------------
 | Ovládací prvky a formuláře ||
 |---------------------------
@@ -135,7 +135,7 @@ var name = {$name}; // pozor, zapisuje se bez uvozovek!
 
 
 
-Podmínky `{if $cond} … {/if}`, `{ifCurrent $link}`, `{$cond ? … : …}` .{toc: Podmínky}
+Podmínky `{if $cond} … {/if}`, `{$cond ? … : …}` .{toc: Podmínky}
 ---------------------------
 
 Podmínky se chovají stejně, jako jejich protějšky v PHP:
@@ -166,31 +166,11 @@ Výraz v podmínce `{if}` lze uvést také v ukončovací značce, což se hodí
 .[caution]
 Blok `{if}` s podmínkou v ukončovací značce nepodporuje makro `{elseif}`. Makro `{else}` použít lze.
 
-Značka `{ifCurrent destination}` pomáhá zjistit, zda-li je cíl odkazu shodný s aktuální stránkou. Pokud odkaz směřuje na stránku, která je zrovna zobrazena, můžeme ho například jinak nastylovat a podobně. Trik je v tom, že při generování odkazu se detekuje, jestli odkaz míří na aktuální stránku. Výsledek pak vrátí `$presenter->getCreatedRequest()->hasFlag('current')`.
-/--html
-<!-- příklady použití -->
-<a href="{link edit, 10}">edituj</a>
-<ul class="menu">
-    <li><a href="{link Default:default}">...</a></li>
-    <li><a href="{link}">...</a></li>
-    ...
-    <li {ifCurrent Default:default}class="current"{/ifCurrent}><a href="{link Default:default}">...</a></li>
-
-    <!-- rozšíření scope -->
-    <li {ifCurrent Default:*}class="current"{/ifCurrent}><a href="{link Default:default}">...</a></li>
-</ul>
-<!-- znegování -->
-{ifCurrent Admin:login}{else}<a href="{link Admin:login}">Přihlašte se!</a>{/ifCurrent}
-\--
-
-Ternární operátor ?: vypíše první hodnotu, pokud je podmínka splněna. V opačném případě vypíše hodnotu druhou. Lze použít i ve zkrácené podobě, kdy se za chybějící hodnotu doplní NULL - tj. nevypíše se nic.
-
 /--html
 dostupnost: {$stock ? 'Skladem' : 'Není dostupné'}
 
 zkráceně: {$stock ? 'Skladem'}
 \--
-
 
 Cykly `{foreach}`, `{for}`, `{while}`  .{toc: Cykly}
 -------------------------

--- a/cs/presenters.texy
+++ b/cs/presenters.texy
@@ -318,11 +318,32 @@ Odkazovat můžeme na určitou část na stránce přes tzv. fragment za znakem 
 <a n:href="show#comments">odkaz na Product:show a fragment #comments</a>
 \--
 
-Makro `n:href` je velmi šikovné, pokud vytváříme HTML značku `<a>`. Pokud chceme odkaz vypsat jinde, například v textu šablony, použijeme makro `{link}` se stejnou vnitřní syntaxí:
+Makro `n:href` je velmi šikovné, pokud vytváříme HTML značku `<a>`. Chceme-li odkaz vypsat jinde, například v textu šablony, použijeme makro `{link}` se stejnou vnitřní syntaxí:
 
 /--html
 Adresa je: {link Product:show $productId}
 \--
+
+Blok uvnitř `{ifCurrent $link}...{/ifCurrent}` se vykoná, pokud je cíl odkazu shodný s aktuální stránkou. Makro je vhodné použít například pokud chceme aktivnímu odkazu přidat CSS třídu.
+
+/--html
+<!-- příklady použití -->
+<a href="{link edit, 10}">edituj</a>
+<ul class="menu">
+    <li><a href="{link Default:default}">...</a></li>
+    <li><a href="{link}">...</a></li>
+    ...
+    <li {ifCurrent Default:default}class="active"{/ifCurrent}><a href="{link Default:default}">...</a></li>
+
+    <!-- rozšíření scope -->
+    <li {ifCurrent Default:*}class="active"{/ifCurrent}><a href="{link Default:default}">...</a></li>
+</ul>
+<!-- znegování -->
+{ifCurrent Admin:login}{else}<a href="{link Admin:login}">Přihlašte se!</a>{/ifCurrent}
+\--
+
+Ternární operátor ?: vypíše první hodnotu, pokud je podmínka splněna. V opačném případě vypíše hodnotu druhou. Lze použít i ve zkrácené podobě, kdy se za chybějící hodnotu doplní NULL - tj. nevypíše se nic.
+
 
 Přečtěte si další podrobnosti o syntaxi [Latte šablon |default-macros].
 

--- a/en/default-macros.texy
+++ b/en/default-macros.texy
@@ -18,7 +18,6 @@ Are you interested in taking a closer look at [Latte syntax |templating#latte]?
 |---------------------------
 | `{if $cond} … {elseif $cond} … {else} … {/if}`  [if condition |#Conditions] ||
 | `{ifset $var} … {elseifset $var} … {/ifset}`  [if (isset()) condition |#Conditions] ||
-| `{ifCurrent $link} … {/ifCurrent}`  |[special case of {if} for an active link |#Conditions]
 |---------------------------
 | Loops ||
 |---------------------------
@@ -72,9 +71,10 @@ Are you interested in taking a closer look at [Latte syntax |templating#latte]?
 |---------------------------
 | Links ||
 |---------------------------
-| `n:href`                       | "link in `<a>` HTML elements":presenters#toc-links-in-templates
-| `{link Presenter:action}`      | [generates a link |presenters#toc-links-in-templates]
-| `{plink Presenter:action}`     | [generates a link to a presenter |presenters#toc-links-in-templates]
+| `n:href`                            | "link in `<a>` HTML elements":presenters#toc-links-in-templates
+| `{link Presenter:action}`           | [generates a link |presenters#toc-links-in-templates]
+| `{plink Presenter:action}`          | [generates a link to a presenter |presenters#toc-links-in-templates]
+| `{ifCurrent $link} … {/ifCurrent}`  | [executes block if the given link is current |presenters#toc-links-in-templates]
 |---------------------------
 | Controls and forms ||
 |---------------------------
@@ -133,7 +133,7 @@ var name = {$name}; // strings are printed with quotes!
 
 
 
-Conditions`{if $cond} … {/if}`, `{ifCurrent $link}` .{toc: Conditions}
+Conditions`{if $cond} … {/if}` .{toc: Conditions}
 ---------------------------
 
 Conditions behave exactly the same way as their PHP counterparts:
@@ -160,26 +160,6 @@ Expression in the `{if}` condition can be placed in the closing macro which is u
 	{foreach $database->table as $row} ... {/foreach}
 {/if $row}
 \--
-
-`{ifCurrent destination}` macro helps to determine if the destination is the same as the current page. If the link points to the current page we are able to style it differently for example. The trick is that when the link is generated it is detected whether it points to the current page. The result is retrieved from $presenter->getCreatedRequest()->hasFlag('current').
-
-/--html
-<!-- use cases -->
-<a href="{link edit, 10}">edit</a>
-<ul class="menu">
-    <li><a href="{link Default:default}">...</a></li>
-    <li><a href="{link}">...</a></li>
-    ...
-    <li {ifCurrent Default:default}class="current"{/ifCurrent}><a href="{link Default:default}">...</a></li>
-
-    <!-- scope expanding -->
-    <li {ifCurrent Default:*}class="current"{/ifCurrent}><a href="{link Default:default}">...</a></li>
-</ul>
-<!-- negation -->
-{ifCurrent Admin:login}{else}<a href="{link Admin:login}">Sign in!</a>{/ifCurrent}
-\--
-
-
 
 Loops `{foreach}`, `{for}`, `{while}`  .{toc: Loops}
 -------------------------

--- a/en/presenters.texy
+++ b/en/presenters.texy
@@ -324,6 +324,24 @@ Macro `n:href` is realy handy when we are creating a HTML tag `<a>`. When we wan
 The address is: {link Product:show $productId}
 \--
 
+`{ifCurrent $link}...{/ifCurrent}` is a conditional statement. If the link is referring to the current page, block inside the tags is executed. Typical use case is adding CSS classes to active link.
+
+/--html
+<!-- use cases -->
+<a href="{link edit, 10}">edit</a>
+<ul class="menu">
+    <li><a href="{link Default:default}">...</a></li>
+    <li><a href="{link}">...</a></li>
+    ...
+    <li {ifCurrent Default:default}class="active"{/ifCurrent}><a href="{link Default:default}">...</a></li>
+
+    <!-- scope expanding -->
+    <li {ifCurrent Default:*}class="active"{/ifCurrent}><a href="{link Default:default}">...</a></li>
+</ul>
+<!-- negation -->
+{ifCurrent Admin:login}{else}<a href="{link Admin:login}">Sign in!</a>{/ifCurrent}
+\--
+
 Read more details about syntax of [Latte templates |default-macros].
 
 


### PR DESCRIPTION
According to @dg['s suggestion](http://forum.nette.org/cs/17100-co-vylepsit-na-dokumentaci), macro {ifCurrent} needs moving from `conditions` to `links` section.

I'm not 100% sure this is right. I would like to hear your opinions on this, thanks in advance :)

EDIT: I will fix the EN version when we agree on a solution.