### PR TITLE
Do not use deprecated code in DI examples

### DIFF
--- a/cs/dependency-injection.texy
+++ b/cs/dependency-injection.texy
@@ -241,7 +241,7 @@ class MyContainer extends Nette\DI\Container
 
 	protected function createServiceArticle()
 	{
-		return new Article($this->connection);
+		return new Article($this->getService('connection'));
 	}
 
 }
@@ -257,7 +257,7 @@ $container = new MyContainer(array(
 ));
 \--
 
-Službu získáme metodu `getService` nebo zkratkou:
+Službu získáme metodu `getService`:
 
 /--php
 $article = $container->getService('article');
@@ -280,7 +280,7 @@ class MyContainer extends Nette\DI\Container
 
 	function createArticle()
 	{
-		return new Article($this->connection);
+		return new Article($this->getService('connection'));
 	}
 
 }

--- a/en/dependency-injection.texy
+++ b/en/dependency-injection.texy
@@ -241,7 +241,7 @@ class MyContainer extends Nette\DI\Container
 
 	protected function createServiceArticle()
 	{
-		return new Article($this->connection);
+		return new Article($this->getService('connection'));
 	}
 
 }
@@ -257,7 +257,7 @@ $container = new MyContainer(array(
 ));
 \--
 
-We get the service by calling the `getService` method or by a shortcut:
+We get the service by calling the `getService` method:
 
 /--php
 $article = $container->getService('article');
@@ -280,7 +280,7 @@ class MyContainer extends Nette\DI\Container
 
 	function createArticle()
 	{
-		return new Article($this->connection);
+		return new Article($this->getService('connection'));
 	}
 
 }


### PR DESCRIPTION
"Deprecated: Nette\DI\Container::__get() is deprecated; use getService()
or enable di.accessors in configuration."
Less magic, less confusion :thumbsup: