### PR TITLE
addText, addPassword, addTextArea: parameter $cols is deprecated

### DIFF
--- a/en/forms.texy
+++ b/en/forms.texy
@@ -958,7 +958,7 @@ How to set more attributes to HTML elements? Methods `getControl()` and `getLabe
 <table>
 <tr class="required">
 	<th>{label name /}</th>
-	<td>{input name cols => 40, autofocus => TRUE}</td>
+	<td>{input name, autofocus => TRUE}</td>
 </tr>
 \--
 
@@ -968,7 +968,7 @@ It's also possible to "breathe life" into a raw HTML input with `n:name` attribu
 <table>
 <tr class="required">
 	<th><label for="frm-name"></th>
-	<td><input cols=40 n:name="name"></td>
+	<td><input n:name="name"></td>
 </tr>
 \--
 


### PR DESCRIPTION
[Closes #220]