### PR TITLE
Ajax: Remove broken link to fifteen example

### DIFF
--- a/cs/ajax.texy
+++ b/cs/ajax.texy
@@ -46,7 +46,7 @@ Když chceme odeslat HTML, můžeme jednak zvolit speciální šablonu pro AJAX:
 	}
 \--
 
-Nicméně daleko silnější nástroj představuje vestavěná podpora AJAXových snippetů. Díky ní lze udělat z obyčejné aplikace AJAXovou prakticky několika řádky kódu.  Jak to celé funguje demonstruje [příklad Fifteen | http://examples.nette.org/fifteen/], jehož kód najdete v distribuci.
+Nicméně daleko silnější nástroj představuje vestavěná podpora AJAXových snippetů. Díky ní lze udělat z obyčejné aplikace AJAXovou prakticky několika řádky kódu. Jak to celé funguje demonstruje příklad Fifteen, jehož kód najdete na [githubu | https://github.com/nette/examples/tree/master/Fifteen].
 
 Snippety fungují tak, že při prvotním (tedy neAJAXovém) požadavku se přenese celá stránka a poté se při každém již AJAXovém [subrequestu |components#signal-neboli-subrequest] (= požadavku na stejný presenter a view) přenáší pouze kód změněných částí ve zmíněném úložišti `payload`. K tomu slouží dva mechanismy: invalidace a renderování snippetů.
 

--- a/en/ajax.texy
+++ b/en/ajax.texy
@@ -44,7 +44,7 @@ If we want to send HTML, we can either set a special template for AJAX requests:
 		...
 	}
 \--
- However, there is a far more powerful tool of built-in AJAX support – snippets. Using them makes it possible to turn a regular application into an AJAX one unsing only a few lines of code. How it all works is demonstrated in the [Fifteen example | http://examples.nette.org/fifteen/] whose code is also accessible in the build or on [Github | https://github.com/nette/examples/tree/master/Fifteen].
+ However, there is a far more powerful tool of built-in AJAX support – snippets. Using them makes it possible to turn a regular application into an AJAX one unsing only a few lines of code. How it all works is demonstrated in the Fifteen example whose code is also accessible in the build or on [Github | https://github.com/nette/examples/tree/master/Fifteen].
 The way snippets work is that the whole page is transferred during the initial (i.e. non-AJAX) request and then with every other AJAX [subrequest |presenters#toc-handle-signal] (request of the same view of the same presenter) only the code of the changed parts is transferred in the earlier mentioned repository called `payload`. There are two mechanisms designated for this: invalidation and snippets rendering.
 
 Invalidation


### PR DESCRIPTION
Fix issue #289.