### PR TITLE
Removed closing {/syntax} from macros preview

### DIFF
--- a/cs/default-macros.texy
+++ b/cs/default-macros.texy
@@ -44,7 +44,7 @@ Zajímají vás bližší informace o [syntaxi Latte |templating#latte] nebo o [
 | `{cache $key} … {/cache}`      | [cachuje část šablony |caching#cachovani-v-sablonach]
 | `{php expression}`             | [vyhodnotí výraz, ale nevypíše |#Vyhodnocení kódu]
 | `{* text komentáře *}`         | komentář, bude odstraněn
-| `{syntax mode} … {/syntax}`    | [změna syntaxe maker za běhu |#Změna syntaxe]
+| `{syntax mode}`                | [změna syntaxe maker za běhu |#Změna syntaxe]
 | `{use Class}`                  | načte nová makra
 | `{l}` nebo `{r}`               | vypíše znak { nebo }
 | `{contentType $type}`          | [přepne escapování a pošle HTTP hlavičku |#hlavicka-contenttype]

--- a/en/default-macros.texy
+++ b/en/default-macros.texy
@@ -42,7 +42,7 @@ Are you interested in taking a closer look at [Latte syntax |templating#latte]?
 | `{cache $key} … {/cache}`      | [caches a template section |caching#caching-in-templates]
 | `{php expression}`             | [evaluates an expression without printing it |#Code evaluation]
 | `{* comment text *}`           | a comment (removed from evaluation)
-| `{syntax mode} … {/syntax}`    | [switches the syntax at runtime |#Syntax switching]
+| `{syntax mode}`                | [switches the syntax at runtime |#Syntax switching]
 | `{use Class}`                  | loads new user-defined macros
 | `{l}` or `{r}`                 | prints { and } characters, respectively
 | `{contentType $type}`          | [switches the escaping mode and sends HTTP header |#header-contenttype]


### PR DESCRIPTION
I shoot my self in a foot trying to do `{syntax off}{$x}{/syntax}` while presenting Latte in work.