### PR TITLE
typo fix in form class - due to 1526

### DIFF
--- a/cs/quickstart/authentication.texy
+++ b/cs/quickstart/authentication.texy
@@ -40,7 +40,7 @@ Začneme s přihlašovacím formulářem. Již víme jak formuláře v presenter
 /--php
 	protected function createComponentSignInForm()
 	{
-		$form = new Form;
+		$form = new Nette\Application\UI\Form;
 		$form->addText('username', 'Uživatelské jméno:')
 			->setRequired('Prosím vyplňte své uživatelské jméno.');
 

--- a/en/quickstart/authentication.texy
+++ b/en/quickstart/authentication.texy
@@ -40,7 +40,7 @@ Let's start with the login form. You already know how forms work in a presenter.
 /--php
 	protected function createComponentSignInForm()
 	{
-		$form = new Form;
+		$form = new Nette\Application\UI\Form;
 		$form->addText('username', 'Username:')
 			->setRequired('Please enter your username.');
 


### PR DESCRIPTION
Due to https://github.com/nette/nette/issues/1526 - it is not clearly that which namespace I have to use