### PR TITLE
en/presenters: fix clunky english, fix spelling errors. No content changes

### DIFF
--- a/en/presenters.texy
+++ b/en/presenters.texy
@@ -2,7 +2,7 @@ MVC Applications & Presenters
 *****************************
 
 /--div .[perex]
-We will learn, how to create applications in Nette Framework. After this chapter you will know:
+We will learn how to create applications in Nette Framework. After this chapter you will know:
 
 - MVC, directory structure and `bootstrap.php` file
 - what are presenters and actions
@@ -14,13 +14,13 @@ We will learn, how to create applications in Nette Framework. After this chapter
 Model-View-Controller (MVC)
 ===========================
 
-Model-View-Controller is a software architecture that was created to satisfy the need to separate utility code (controller) from application logic code (model) and from code for displaying data (view) in applications with graphical user interface. With this approach we make the application better understandable, simplify future development and enable testing each unit of the application separately.
+Model-View-Controller is a software architecture that was created to separate utility code (controller) from application logic code (model) and from code for displaying data (view) in applications with a graphical user interface. With this approach the application is easier to understand, it will simplify future development and enables us to test each unit of the application separately.
 
 
 Model
 -----
 
-Model is data and especially functional base of whole application. It contains application logic. Any user action (login, insertion of goods to basket, change of value in database) represents a model action. Model is managing its internal state and provides solid interface to outside. By calling methods of this interface, we can read or update its state. Model doesn't know anything about view or controller.
+Model is data and it is the functional base of the whole application. It contains application logic. Any user action (login, insertion of goods to basket, a change of value in the database) represents a model action. The Model is managing its internal state and provides a stable interface to the outside. By calling methods on this interface, we can read or update its state. The Model doesn't know anything about View or Controller.
 
 .[note]
 Concept of *Model* represents whole layer, not only a single class.
@@ -29,20 +29,20 @@ Concept of *Model* represents whole layer, not only a single class.
 View
 ----
 
-View is an application layer, that is taking care of displaying result of request. It usualy uses templating engine and knows, how should be each component rendered or result acquired from model.
+View is an application layer that is taking care of displaying. It usually uses the templating engine and knows how each component should be rendered by getting data from the model.
 
 
 Controller
 ----------
 
-Controller does handle requests from user, calls relevant application logic (model) and then asks view to display data. Analogically for controllers in Nette Framework there are [presenters |glossary#presenter].
+A controller handles requests from the user, calls relevant application logic (Model) and then asks the View to display data. In Nette Framework, controllers are represented by [presenters |glossary#presenter].
 
 
 
 Directory structure
 ===================
 
-When you look at `sandbox` after downloading of Nette Framework package, you will see recommended directory structure:
+When you look at `sandbox` after downloading the Nette Framework package you will see the following recommended directory structure:
 
 /--pre
 <b>sandbox/</b>
@@ -51,13 +51,13 @@ When you look at `sandbox` after downloading of Nette Framework package, you wil
 │   │   └── <b>config.neon</b>   ← main config file
 │   │   └── <b>config.local.neon</b>
 │   │
-│   ├── <b>model/</b>            ← model layer and it's classes
+│   ├── <b>model/</b>            ← model layer and its classes
 │   ├── <b>presenters/</b>       ← presenter classes
 │   │   └── <b>HomepagePresenter.php</b>  ← Homepage presenter class
 │   │
 │   ├── <b>templates/</b>        ← templates directory
 │   │   ├── <b>@layout.latte</b> ← template of shared layout
-│   │   └── <b>Homepage/</b>     ← tempaltes for Homepage presenter
+│   │   └── <b>Homepage/</b>     ← templates for Homepage presenter
 │   │       └── <b>default.latte</b>  ← template for default action
 │   │
 │   └── <b>bootstrap.php</b>     ← application boot file
@@ -65,7 +65,7 @@ When you look at `sandbox` after downloading of Nette Framework package, you wil
 ├── <b>log/</b>                  ← contains logs, errors, etc.
 ├── <b>temp/</b>                 ← for temporary files, cache, ...
 │
-├── <b>vendor/</b>               ← directory with libraries (for example 3rd parties)
+├── <b>vendor/</b>               ← directory with libraries (for example 3rd party)
 │   ├── <b>nette/</b>            ← all Nette Framework libraries
 │   │   └── <b>nette/Nette</b>   ← Nette Framework itself installed by Composer
 │   ├── ...
@@ -75,10 +75,10 @@ When you look at `sandbox` after downloading of Nette Framework package, you wil
 └── <b>www/</b>                  ← public directory, document root of project
     ├── <b>.htaccess</b>         ← rules for mod_rewrite
     ├── <b>index.php</b>         ← triggers the application
-    └── <b>images/</b>           ← another directories, images, styles, ..
+    └── <b>images/</b>           ← other directories, images, styles, ..
 \--
 
-Moreover in some directories, there are `.htaccess` and `web.config` files, that denies access from browser (for Apache or IIS). Make sure, that this is working, and you cannot reach `app/` and `libs/` directories from browser.
+Moreover in some directories, there are `.htaccess` and `web.config` files, which deny access from browser (for Apache or IIS). Make sure that these are working, and that you cannot reach `app/` and `libs/` directories from your browser.
 
 .[note]
 Don't forget to grant write privilege (`chmod 0777`) to directories `log/` and `temp/`.
@@ -87,20 +87,20 @@ Don't forget to grant write privilege (`chmod 0777`) to directories `log/` and `
 index.php & bootstrap.php
 -------------------------
 
-Browser is sending all requests through one and only file, located in public directory `www/` and that is `index.php`. It only passes the control to the application (that is the `app/` directory), to a boot file `bootstrap.php`.
+The browser is sending all requests through one and only one file, located in public directory `www/` and that is `index.php`. It only passes the control to the application (that is the `app/` directory), to a boot file `bootstrap.php`.
 
 .[note]
 Nette Framework saves all its paths consistently, without the right trailing slash.
 
-Described directory structure is realy just recommended, because you can easily change it however you want to. All you have to do, is rename directories and change paths in `bootstrap.php`.
+The described directory structure is only a recommendation. You can easily change it to whatever you want. All you have to do is rename directories and change paths in `bootstrap.php`.
 
-First, file `bootstrap.php` loads Nette Framework and all libraries that we depend on:
+Firstly, the file `bootstrap.php` loads Nette Framework and all libraries that we depend on:
 
 /--php
 require __DIR__ . '/../vendor/autoload.php';
 \--
 
-Class `Configurator` creates so called [DI context |configuring] and handles application initialization.
+The class `Configurator` creates so called [DI context |configuring] and handles application initialization.
 
 /--php
 $configurator = new Nette\Configurator;
@@ -138,7 +138,7 @@ $configurator->addConfig(__DIR__ . '/config/config.local.neon');
 return $configurator->createContainer();
 \--
 
-and we will store it as local variable in `www/index.php` and run the application:
+and we will store it as a local variable in `www/index.php` and run the application:
 
 /--php
 $container = require __DIR__ . '/../app/bootstrap.php';
@@ -151,11 +151,11 @@ That's it.
 Processing presenter action
 ===========================
 
-Now listen up closely, please. Every request on our application will reach through files `index.php` and `bootstap.php` into object `$application`. But, that one doesn't understand to http requests, because of that, it will ask the [router | routing], to translate the request into something, that it can understand. Thus to tell him, for what **presenter** is the request meant and what **action** should it execute. For example, router answers, that user want's action `show` of presenter `Product` (it's good habit to write it like `Product:show`) and passes parameter `id = 123`. You can read it like: user want's to show product with id 123.
+So how are requests handled? Every request to our application will pass via `index.php` and `bootstrap.php` to the `$application` object. But this object does not understand http requests, so it will ask the [router | routing] to translate the request. The router will look at the request, and tells what **presenter** is needed, and what **action** it should execute. For example, the router answers, that the user wants action `show` of presenter `Product` (it's a good habit to write it like `Product:show`) and pass it parameter `id = 123`. You can read it like: user wants to show product with id 123.
 
-This is finally understandable to `$application` and it will proceed to fulfill the wishes. It will create an object of class `ProductPresenter`, that represents presenter `Product`. (To be completely accurate, application asks for creation of presenter the `presenterFactory` service). And presenter will be asked for execution of action (`show` with parameter `id`).
+This is finally understandable to the `$application` and it will proceed to fulfill the request. It will create an object of class `ProductPresenter`, that represents presenter `Product`. (To be completely accurate, the application asks the `presenterFactory` service for creation of a presenter). This new presenter will be asked for execution of action (`show` with parameter `id`).
 
-Presenter is an object, that takes the request, translated by router and devises the answer. Answer can be HTML page, image, XML document, file on hard drive, JSON, redirection or anything that you need. Specifically `ProductPresenter` asks model for data, that it will pass to template for displaying. This is usually done in method `renderShow`, where word `Show` corresponds to the name of action and request parameter `id` will be passed to the method as argument:
+The presenter is an object that takes the request, translated by router, and computes the answer. This can be an HTML page, an image, an XML document, a file, JSON, redirection or anything that you need. In detail, the `ProductPresenter` will query the model for data, and pass that data to the template for displaying. This is usually done in method `renderShow`, where the word `Show` must match the name of the action and request parameter `id` will be passed to the method as argument:
 
 /--php
 class ProductPresenter extends Nette\Application\UI\Presenter
@@ -168,9 +168,9 @@ class ProductPresenter extends Nette\Application\UI\Presenter
 }
 \--
 
-You get array of all parameters sended to the application using GET request by calling `$this->request->getParameters()`. But usually you shouldn't need them, rather use [routing] and [action parameters |#processing presenter action].
+If you really want, you can get an array of all the GET request parameters by calling `$this->request->getParameters()`, but usually you shouldn't need them, bu instead use [routing] and [action parameters |#processing presenter action].
 
-Similarly you can get all received POST parameters by calling `$this->request->getPost()`. And you shouldn't need not even this method. Mostly you're processing form requests and there is a [form component for that|forms#toc-presenter-forms].
+Similarly you can get all received POST parameters by calling `$this->request->getPost()`. And normally, neither should you need this method. Mostly you're processing form requests and there is a [form component for that|forms#toc-presenter-forms].
 
 Then the presenter will render the template.
 
@@ -178,7 +178,7 @@ Then the presenter will render the template.
 Templates
 ---------
 
-Presenter will deduce the path to the template file from simple logic. It will try, for presenter `Product` and action `show`, if one of these files exists:
+The presenter will deduce the path to the template file from a few simple rules. It will try, for presenter `Product` and action `show`, if one of these files exists:
 
 /--
 - templates/Product/show.latte
@@ -196,7 +196,7 @@ Presenter will also try to search for a layout (that is optional):
 .[tip]
 You can change the way of searching the templates by overriding the [formatTemplateFiles |api:Nette\Application\UI\Presenter::formatTemplateFiles()] or [formatLayoutTemplateFiles |api:Nette\Application\UI\Presenter::formatLayoutTemplateFiles()] methods.
 
-Presenters and its components passes to the templates few useful variables:
+Presenters and its components pass a few useful variables to the templates:
 
 - `$basePath` is an absolute URL path to root dir (for example `/CD-collection`)
 - `$baseUrl` is an absolute URL to root dir (for example `http://localhost/CD-collection`)
@@ -219,13 +219,13 @@ and in template we can [create a link |#Linking] to mentioned `Product:show($id)
 <a n:href="Product:show $productId">product detail</a>
 \--
 
-I looks like that creating applications in Nette Framework will be a child play.
+It looks like creating applications in Nette Framework will be child's play.
 
 
 Modules
 -------
 
-When developing complex applications, we can separate directories with presenters and templates to subdirectories. We call them modules. If our application would contain, for example modules `Front` and `Admin`, its structure could look like this:
+When developing complex applications, we can separate directories with presenters and templates to subdirectories. We call them modules. If our application would contain for example modules `Front` and `Admin`, its structure could look like this:
 
 /--pre
 <b>sandbox/</b>
@@ -241,7 +241,7 @@ When developing complex applications, we can separate directories with presenter
 		...
 \--
 
-Modules don't have to be arranged in flat structure, you can even create submodules.
+Modules don't have to be arranged in flat structures, you can even create submodules.
 
 If module `Front` would contain presenter `Product`. Action `show` can than be written as `Front:Product:show` and class `ProductPresenter` will be placed into namespace `FrontModule`:
 
@@ -258,49 +258,49 @@ class ProductPresenter extends \Nette\Application\UI\Presenter
 Link creation
 =============
 
-Creation of links belongs to the strongest features of Nette Framework. Thanks to [two-way routing |routing] you don't have to hardcode your URLs or nastily assemble them. You can just refer to actions of presenters, and pass them parameters and framework will generate URLs by itself. Creating links is as easy as calling a function. You will really like it!
+Creation of links belongs to the strongest features of Nette Framework. Thanks to [two-way routing |routing] you don't have to hardcode your URLs or nastily assemble them. You can just refer to actions of presenters, and pass them parameters and the framework will generate URLs by itself. Creating links is as easy as calling a function. You will really like it!
 
-When programming and coding templates, we don't have to care about URLs design, we will refer directly to action of presenter, that's for example already mentioned `Product:show`.
+When programming and coding templates, we don't have to care about URLs design, we will refer directly to action of presenter, that's for example the already mentioned `Product:show`.
 
 
 Links in templates
 ------------------
 
-Most often we create links in templates. To make it as easy as possible, framework does offer three macros. Smartest of them is macro `n:href`
+Most often we create links in templates. To make it as easy as possible the framework offers three macros. The smartest of them is `n:href`
 
 /--html
 <a n:href="Product:show $productId">product detail</a>
 \--
 
-Note, that instead of the HTML attribute `href` we've used [n:macro |templating#n-macros] `n:href`. It's value isn't a URL, as you were used to at `href` attribute, but directly an action of a presenter. The syntax is
+Note, that instead of the HTML attribute `href` we've used [n:macro |templating#n-macros] `n:href`. Its value isn't a URL, as you are used to with the `href` attribute, but directly an action of a presenter. The syntax is
 
 /--
 [Presenter:]action [,] [arg1] [, arg2] [, ...]
 \--
 
-After clicking on the link, method `ProductPresenter::renderShow()` will get its word and as parameter `$id` will get the value of `$productId`, We can pass even more parameters, in the same way, as we call a method. Could it get any easier?
+After clicking on the link, method `ProductPresenter::renderShow()` will get its word and as parameter `$id` will get the value of `$productId`. We can pass even more parameters in the same way, just like we call a method. Could it get any easier?
 
 .[note]
-Best practise is to follow convetion of first big letter for name of presenter and small for action. As separator is used colon.
+Best practise is to write the presenter with a capital letter and the action without. The separator is a colon.
 
-Besides that, it's even possible to pass named parameters. Next link passes parameter `lang` with value `cs`:
+Besides that, it's even possible to pass named parameters. The next link passes the parameter `lang` with value `cs`:
 
 /--html
 <a n:href="Product:show $productId, lang => cs">product detail</a>
 \--
 
-Allthough method `renderShow` doesn't have `$lang` in it's declaration, it can read the value of this parameter by calling `$lang = $this->getParameter('lang')`.
+Although the method `renderShow` doesn't have `$lang` in its declaration, it can read the value of this parameter by calling `$lang = $this->getParameter('lang')`.
 
-If we have all parameters in array, we can expand them with `(expand)` operator:
+If we have all parameters in an array, we can expand them with `(expand)` operator:
 
 /--html
 {var $args = [$productId, lang => cs]}
 <a n:href="Product:show (expand) $args">product detail</a>
 \--
 
-If the template, in which we are creating links, is part of `Product` presenter, we can omit the name of the presenter and write directly `n:href="show $productId"`. Or the other way, if a link leads to the an action named `default`, you can skip that and write `n:href="Product: $id"` (don't forget the colon).
+If the template, in which we are creating links, is part of the `Product` presenter, we can omit the name of the presenter and write directly `n:href="show $productId"`. Similarly, if a link leads to the an action named `default`, you can skip that and write `n:href="Product: $id"` (don't forget the colon).
 
-Links can even refer to other [modules |#modules]. Here we distinguish, if it's refering "relatively" to submodule, or "absolutely" to different module - then path begins with colon. Lets assume, that actual presenter is part of module `Front`, then we will write:
+Links can even refer to other [modules |#modules]. Here we distinguish, if it's refering "relatively" to a submodule, or "absolutely" to a different module - then the path begins with a colon. Let's assume that the actual presenter is part of module `Front`, then we will write:
 
 /--html
 <a n:href="Shop:Product:show">link for Front:Shop:Product:show</a>
@@ -308,23 +308,23 @@ Links can even refer to other [modules |#modules]. Here we distinguish, if it's 
 \--
 
 .[note]
-Special case is linking to itself, when we'll write `this` as the target.
+A special case is linking to itself. Here we'll write `this` as the target.
 
-Generated link is in absolute path format. When you want to generate absolute link including domain, for example `http://example.com`, we will supply two slashes at the beginning `n:href="//show $productId"`. If we set the property  [$absoluteUrls | api:Nette\Application\UI\Presenter::$absoluteUrls] in presenter to `TRUE`, all the links will be absolute by default.
+The generated link is in absolute path format. When you want to generate an absolute link including the domain, for example `http://example.com`, simply supply two slashes at the beginning `n:href="//show $productId"`. If we set the property  [$absoluteUrls | api:Nette\Application\UI\Presenter::$absoluteUrls] in presenter to `TRUE`, all the links will be absolute by default.
 
-We can refer to specific part on page using so called fragments behind the symbol of grid `#`:
+We can refer to specific parts on the page using so called fragments, or anchors, with the hash `#` symbol:
 
 /--html
 <a n:href="show#comments">link to Product:show and fragment #comments</a>
 \--
 
-Macro `n:href` is realy handy when we are creating a HTML tag `<a>`. When we want to print link elsewhere, for example in text of the template, we will use macro `{link}` with the same internal syntax:
+The macro `n:href` is realy handy if we are creating an HTML tag `<a>`. When we want to have this link elsewhere, for example in the text of the template, we can use the `{link}` macro with the same internal syntax:
 
 /--html
 The address is: {link Product:show $productId}
 \--
 
-`{ifCurrent $link}...{/ifCurrent}` is a conditional statement. If the link is referring to the current page, block inside the tags is executed. Typical use case is adding CSS classes to active link.
+`{ifCurrent $link}...{/ifCurrent}` is a conditional statement. If the link is referring to the current page, the block inside the tags is executed; otherwise it is discarded. Typical use case is adding CSS classes to the active link.
 
 /--html
 <!-- use cases -->
@@ -342,13 +342,13 @@ The address is: {link Product:show $productId}
 {ifCurrent Admin:login}{else}<a href="{link Admin:login}">Sign in!</a>{/ifCurrent}
 \--
 
-Read more details about syntax of [Latte templates |default-macros].
+Read more details about the syntax of [Latte templates |default-macros].
 
 
 Linking in presenter
 --------------------
 
-Presenter and [a component | api:Nette\Application\UI\PresenterComponent] have method `link`, which can be used to create links just like in a template. First argument is presenters target action, followed by passed arguments:
+Presenter and [a component | api:Nette\Application\UI\PresenterComponent] have the method `link`, which can be used to create links just like in a template. The first argument is presenters target action, followed by passed arguments:
 
 /--php
 $url = $this->link(destination [,arg [,arg ...]]);
@@ -363,20 +363,20 @@ $url = $this->link('Product:show', array($productId, 'lang' => 'en'));
 \--
 
 .[caution]
-If you pass `FALSE` as method parameter when generating a link, it won't be added to the link at all. The solution is to define this parameter with default value `TRUE` or `FALSE`. Nette will then understand, that it's type is boolean, and it will be passed to url as 1 or 0, and converted back to boolean when processed by presenter.
+If you pass `FALSE` as method parameter when generating a link, it won't be added to the link at all. The solution is to define this parameter with default value `TRUE` or `FALSE`. Nette will then understand that its type is boolean, and it will be passed to the url as 1 or 0, and converted back to boolean when processed by a presenter.
 
 
 Invalid links
 -------------
 
-It may happen that we create an invalid link - either because it refers to non-existing presenter, or because it passes more parameters that the target method receives in its definition, or when there can't be generated URL for targeted action. What to do with invalid link is determined by static variable `Presenter::$invalidLinkMode`. It can have one of these values (constants):
+It may happen that we create an invalid link - either because it refers to a non-existing presenter, or because it passes more parameters that the target method receives in its definition, or when there can't be a generated URL for the targeted action. What to do with invalid links is determined by the static variable `Presenter::$invalidLinkMode`. It can have one of these values (constants):
 
-- `Presenter::INVALID_LINK_SILENT` - silent mode, there will be returned symbol `#` as  URL
+- `Presenter::INVALID_LINK_SILENT` - silent mode, returns symbol `#` as URL
 - `Presenter::INVALID_LINK_WARNING` - E_USER_WARNING will be produced
 - `Presenter::INVALID_LINK_TEXTUAL` - visual warning, the error text is displayed in the link
 - `Presenter::INVALID_LINK_EXCEPTION` - InvalidLinkException will be thrown
 
-Default setup in production mode is `INVALID_LINK_WARNING` and in development mode it's `INVALID_LINK_WARNING | INVALID_LINK_TEXTUAL`. `INVALID_LINK_WARNING` doesn't kill the script in the production environment, but the warning will be logged. In the development environment, Tracy will intercept the warning and display the bluescreen. If the `INVALID_LINK_TEXTUAL` is set, presenter and components returns error message as URL which stars with `#error:`. To make such links visible, we will add CSS rule to our stylesheet:
+Default setup in production mode is `INVALID_LINK_WARNING` and in development mode is `INVALID_LINK_WARNING | INVALID_LINK_TEXTUAL`. `INVALID_LINK_WARNING` doesn't kill the script in the production environment, but the warning will be logged. In the development environment, Tracy will intercept the warning and display the error bluescreen. If the `INVALID_LINK_TEXTUAL` is set, presenter and components returns error message as URL which stars with `#error:`. To make such links visible, we can add a CSS rule to our stylesheet:
 
 /--code css
 a[href^="#error:"] {
@@ -385,7 +385,7 @@ a[href^="#error:"] {
 }
 \--
 
-If we don't want warning to be produced in development enviroment, we can turn on silent invalid link mode in the configuration.
+If we don't want warnings to be produced in the development enviroment we can turn on silent invalid link mode in the configuration.
 
 /--
 application:
@@ -395,9 +395,9 @@ application:
 Persistent parameters
 ---------------------
 
-Except classic parameters, that we know by now, there are so called persistent parameters. Those are different in a very essential feature: **they are passed through requests automatically.** That means, we doesn't have to explicitly mention them in links, but they are anyway passed.
+Except classic parameters, that we know by now, there are so called persistent parameters. Those are different in a very essential way: **they are passed through requests automatically.** That means, we don't have to explicitly mention them in links, but they are passed anyway.
 
-When your application have multiple language variants, passing of actual language in every link will be incredibly tiring. But that's not needed with Nette Framework. You can simply mark the `$lang` parameter as persistent just like this:
+When your application has multiple language variants passing the actual language in every link will be incredibly tiring. But that's not needed with Nette Framework. You can simply mark the `$lang` parameter as persistent just like this:
 
 /--php
 class ProductPresenter extends Presenter
@@ -414,7 +414,7 @@ If the actual value of parameter `$lang` will be `'en'`, the into the link
 <a n:href="Product:show $productId">product detail</a>
 \--
 
-will be automaticaly passed parameter `lang => en`. Great!
+the parameter `lang => en` will be passed automatically. Great!
 
 But we can also add parameter `lang` and by that, change its value:
 
@@ -422,19 +422,19 @@ But we can also add parameter `lang` and by that, change its value:
 <a n:href="Product:show $productId, lang => cs">detail in Czech language</a>
 \--
 
-The parameter will be accessible in class variable `$lang` in object of `ProductPresenter` and it can be accessed through `$this->lang`. We can even set the default value of persistent parameter to presenter class. If the parameter value will correspond to default value, it will not be passed in URL.
+The parameter will be accessible in the class variable `$lang` in objects of `ProductPresenter` and it can be accessed through `$this->lang`. We can even set the default value of the persistent parameter to presenter class. If the parameter value will correspond to the default value, it will not be passed in a URL.
 
 .[note]
-Persistent variable must be declared as public.
+A persistent variable must be declared as public.
 
-Persistence reflects hierarchy of presenter classes, thus parameter defined in specific presenter will be automaticaly taken into account in every single presenter that inheriting from it.
+Persistence reflects hierarchy of presenter classes, thus parameter defined in specific presenter will be automaticaly taken into account in every single presenter inheriting from it.
 
 
 
 Life cycle of presenter
 =======================
 
-We know by now, that a presenter action causes invoking `render<Action>` method, thus for example `renderShow`. But it's not the only method, that gets invoked. When writing presenters, we can write following methods:
+We know by now that a presenter action causes invoking `render<Action>` method, thus for example `renderShow`. But it's not the only method that gets invoked. When writing presenters, we can write the following methods:
 
 
 [* lifecycle2.gif *] *** *Life cycle of presenter* .<>
@@ -446,15 +446,15 @@ We know by now, that a presenter action causes invoking `render<Action>` method,
 Method `startup()` gets invoked immediately after the presenter is created. It initializes variables or checks user privileges.
 
 .[note]
-If you write your own `startup()` method, don't forget to call its ancestors `parent::startup()`.
+If you write your own `startup()` method, don't forget to call its parent `parent::startup()`.
 
 
 `action<Action>()`
 ------------------
 
-Analogy to method `render<View>()`. There are situations, when presenter executes some specific action (authenticates the user, writes to database) and then redirects to somewhere else. Name such a method `render` would be inappropriate, because method doesn't render anything. Because of that, there is alternative with name `action`.
+Analogous to the method `render<View>()`. There are situations when the presenter executes some specific action (authenticates the user, writes to database) and then redirects to somewhere else. To call it `render` would be inappropriate, because nothing is rendered. Because of that, there is an alternative called `action`.
 
-It's important to know, that method `action<Action>()` get's called before `render<View>()` method. It can even decide to change what render method gets invoked, by calling `$this->setView('otherView')` (`renderOtherView()` will get invoked).
+It's important to know that the method `action<Action>()` gets called before `render<View>()`. It can even decide to change what render method gets invoked, by calling `$this->setView('otherView')` (`renderOtherView()` will get invoked).
 
 
 `handle<Signal>()`
@@ -481,52 +481,52 @@ Usualy passes required data to templates.
 Gets invoked at the end of the presenters life cycle.
 
 .[note]
-More accurate would be to say, that we were talking about life cycle of class [api:Nette\Application\UI\Presenter], from which are presenters inherited most often. In general, presenter is any class implementing simple interface [api:Nette\Application\IPresenter].
+More accurate would be to say, that we were talking about life cycle of the class [api:Nette\Application\UI\Presenter], from which presenters are inherited most often. In general, a presenter is any class implementing the simple interface [api:Nette\Application\IPresenter].
 
 
 Termination of presenter
 ------------------------
 
-We can terminate presenter anytime during his life cycle. We usualy do this, to prevent rendering a template.
+We can terminate a presenter anytime during its life cycle. We usualy do this to prevent rendering a template.
 
 - termination of presenter directly by method: `$presenter->terminate()`
 - termination of presenter and immediate render the template: `$presenter->sendTemplate()`
 - termination of presenter and dispatch of the payload: `$presenter->sendPayload()` (for AJAX)
 - termination of presenter and dispatch of own response: `$presenter->sendResponse($response)`
 
-Presenter can be terminated also by redirecting or by throwing a `BadRequestException`.
+A presenter can be terminated also by redirecting or by throwing a `BadRequestException`.
 
 
 Redirection
 ===========
 
-There are two methods `redirect()` and `forward()` for jumping to another presenter, which have similar syntax as mentioned [link() |#linking]. For example after submitting a form and writing to database, we will redirect to the products detail by calling:
+There are two methods `redirect()` and `forward()` for jumping to another presenter, which have similar syntax as mentioned [link() |#linking]. For example, after submitting a form and writing to the database, we will redirect to the product's detail by calling:
 
 /--php
 $this->redirect('Product:show', $id);
 \--
 
-While `forward()` will pass to new action without redirecting, method `redirect()` will redirect browser with HTTP code 302 or 303. If we would want to use different code, we will put it before the name of the action of presenter:
+While `forward()` will pass to new action without redirecting, method `redirect()` will redirect the browser with HTTP code 302 or 303. If we would want to use a different code, we will put it before the name of the action of a presenter:
 
 /--php
 $this->redirect(301, 'Product:show', $id);
 \--
 
-To different URLs to outside of application, you can redirect using `redirectUrl()`:
+To go to URLs outside of your application, you can redirect using `redirectUrl()`:
 
 /--php
 $this->redirectUrl('http://nette.org');
 \--
 
-Redirection immediately terminates activity of the presenter by throwing so called terminating exception `Nette\Application\AbortException`.
+Redirection immediately terminates activity of the presenter by throwing the so called terminating exception `Nette\Application\AbortException`.
 
-Sometimes, before redirection, we want to send so called [flash message |#flash messages]. That's a message, that will appear after redirection in template.
+Sometimes, before redirection, we want to send a so called [flash message |#flash messages]. That's a message that will appear after redirection in template.
 
 
 Error 404, etc.
 ===============
 
-When we can't fulfill the request, because for example the record is missing in database, we will throw an exception `Nette\Application\BadRequestException`, which represents HTTP error 404:
+When we can't fulfill the request, because for example the record is missing in the database, we will throw an exception `Nette\Application\BadRequestException`, which represents HTTP error 404:
 
 /--php
 public function renderShow($id)
@@ -540,15 +540,15 @@ public function renderShow($id)
 }
 \--
 
-When user is not authorized to see the page, we will throw a `Nette\Application\ForbiddenRequestException` exception (error 403). Other error codes can be returned using second argument of `Nette\Application\BadRequestException`.
+When a user is not authorized to see the page, we will throw a `Nette\Application\ForbiddenRequestException` exception (error 403). Other error codes can be returned using second argument of `Nette\Application\BadRequestException`.
 
 
 Flash messages
 ==============
 
-These are messages informing about a result of some operation. Important feature of flash messages is, that they are available in template, even after redirection. Even when displayed, they are available next three seconds - in case that user would unintentionally refresh page - thus messages will not be lost.
+These are messages informing about a result of some operation. An important feature of flash messages is that they are available in template, even after redirection. Even when displayed, they are available for three seconds - in case that a user would unintentionally refresh the page - thus messages will not be lost.
 
-Just call the [flashMessage() |api:Nette\Application\UI\Control::flashMessage()] method and presenter will take care about passing the message to template. First argument is text of message and second optional argument is it's type (error, warning, info etc.). Method `flashMessage()` returns an instance of flash message, to allow us to add more information.
+Just call the [flashMessage() |api:Nette\Application\UI\Control::flashMessage()] method and presenter will take care about passing the message to template. First argument is the text of the message and second optional argument is its type (error, warning, info etc.). The method `flashMessage()` returns an instance of flash message, to allow us to add more information.
 
 /--php
 public function deleteFormSubmitted($form)
@@ -574,7 +574,7 @@ These messages are available in templates variable `$flashes` as anonymous objec
 Usage of model classes
 ======================
 
-As we've said before, model is a whole layer composed of many classes, where each one is taking care of one part of application logic. If we'd have for example model `App\Articles`, which would take care of loading and saving articles, we could ask for it in presenter using [Dependency Injection | dependency-injection], assuming we've [properly registered it as a service |configuring#toc-services-definitions] in [DI Container |dependency-injection#toc-nette-di-container].
+As we've said before, model is a whole layer composed of many classes, where each one is taking care of one part of application logic. If we'd have for example a model `App\Articles`, which would take care of loading and saving articles, we may ask for it in a presenter using [Dependency Injection | dependency-injection], assuming we've [properly registered it as a service |configuring#toc-services-definitions] in [DI Container |dependency-injection#toc-nette-di-container].
 
 /--php
 class ArticlePresenter extends Presenter
@@ -591,22 +591,22 @@ class ArticlePresenter extends Presenter
 }
 \--
 
-What just happened? Let's go through it together. As we've said before, instance of presenters is created using [PresenterFactory |api:Nette\Application\PresenterFactory] and what this class does after creating it, is that it checks if the presenter has some public properties, that are annotated with `@inject` and if so, it tries to find a service that implments or is instance of the type, that is in `@var` and passes this service to the property from DI Container.
+What just happened? Let's go through it together. As we've said before, instances of presenters are created using the [PresenterFactory |api:Nette\Application\PresenterFactory] and what this class does after creation, is that it checks if the presenter has some public properties, that are annotated with `@inject` and if so, it tries to find a service that implements or is instance of the type, that is in `@var` and passes this service to the property from DI Container.
 
-Thanks to this mechanism, we can use the service right away, without caring where it came from or trying to instantiate it, because we're sure that it will be passed to the property, if it's correctly registered in the DI Container.
+Thanks to this mechanism, we can use the service right away, without caring where it came from or trying to instantiate it, because we're sure that it will be passed to the property, as long as it's correctly registered in the DI Container.
 
-It is possible to inject only into public properties of classes.
+You can only inject into public properties of classes.
 
 
 Presenter and components
 ========================
 
-When we talk about presenters, then under the term [components |components] we usually mean descendants of class [Control |api:Nette\Application\UI\Control]. More accurate would be to use term "controls", but it has different meaning in czech language and "components" did better catch on.
+When we talk about presenters, then under the term [components |components] we usually mean descendants of class [Control |api:Nette\Application\UI\Control]. More accurate would be to use term "controls", but it has a different meaning in czech and "components" did better catch on.
 
-Presenter `Nette\Application\UI\Presenter` by itself, is descendant of class `Control`, so there is major similarity between components and presenter. But mainly `UI\Control` (and thus even `UI\Presenter`) is so called component container. Which means, that you can add to it another components. Just like we add to [form |forms] inputs (text field, button, ...). And just like with forms, you can access them through brackets:
+Presenter `Nette\Application\UI\Presenter` by itself, is descendant of class `Control`, so there is major similarity between components and presenter. But `UI\Control` (and thus even `UI\Presenter`) is primarily a so called component container. Which means that you can add to it other components. Just like we add to [form |forms] inputs (text field, button, ...). And just like with forms, you can access them through brackets:
 
 /--php
-// attach component at presenter
+// attach component to presenter
 $presenter['mymenu'] = new MenuControl;
 
 // get component from presenter and render it
@@ -624,7 +624,7 @@ When you don't need any of these features, you don't have to bind the component 
 Component factories
 -------------------
 
-Component factories is an elegant way to create components only when they are realy needed (lazy / on demand). Whole magic is in implementation of method with name `createComponent<Name>()`, where `<Name>` is the name of component, that will create and return desired component. Component is then attached to presenter. To method `createComponent<Name>()` is optionaly passed `$name` of component, that is beeing created, as argument.
+Component factories are an elegant way to create components only when they are realy needed (lazy / on demand). The whole magic is in implementation of a method called `createComponent<Name>()`, where `<Name>` is the name of component, that will create and return the desired component. This component is then attached to the presenter. The method `createComponent<Name>()` is optionaly passed the `$name` of the component, that is being created, as an argument.
 
 /--php
 class DefaultPresenter extends Nette\Application\UI\Presenter
@@ -648,11 +648,11 @@ class DefaultPresenter extends Nette\Application\UI\Presenter
 \--
 
 .[note]
-Component name always starts with lowercase letter, despite that they are with uppercased first letter in name of factory.
+The first letter of a component name is always lower case, despite that the first letter in the factory name is upper case.
 
-Because all components are created in separated methods, the code is cleaner and easier to read.
+Because all components are created in separate methods, the code is cleaner and easier to read.
 
-We never call factories directly, it gets called automatically, when we use the component for the first time. Thanks to that, the component is created at the right moment, and only if it's really needed. If we wouldn't use the component (for example on some AJAX request, where we return only part of the page, or when parts are cached), it wouldn't even be created and we save performance of the server.
+We never call factories directly, they get called automatically, when we use components for the first time. Thanks to that, a component is created at the right moment, and only if it's really needed. If we wouldn't use the component (for example on some AJAX request, where we return only part of the page, or when parts are cached), it wouldn't even be created and we save performance of the server.
 
 You can access and render component using [macro {control} |default-macros#toc-components-rendering]. So there is no need of manualy passing the components to template.
 
@@ -668,7 +668,7 @@ You can read more detailed information about components on a [separate page |com
 Persistent components
 ---------------------
 
-Not even parameters, but also components can be persistent. Their state is then passed around when jumping to another presenter, just like with [persistent parameters |#persistent parameters]. We mark persistent components with this annotation (here we mark components `calendar` and `menu`):
+Not only parameters, but also components can be persistent. Their state is then passed around when jumping to another presenter, just like with [persistent parameters |#persistent parameters]. We mark persistent components with this annotation (here we mark components `calendar` and `menu`):
 
 /--php
 /**
@@ -680,7 +680,7 @@ class DefaultPresenter extends Presenter
 }
 \--
 
-You don't have to mark subcomponents as persistent, they would be persistent automatically too.
+You don't have to mark subcomponents as persistent, they are persistent automatically.
 
 
 Where can i get some components?


### PR DESCRIPTION
I really like the Nette framework, and it is nicely documented. However, since I do not speak czech, I have to rely on the english documentation which is at times - shall we say - a bit clumsy. I have taken the opportunity to improve parts of it, and remove some small spelling mistakes alongside.
For starters I thought it best to attack a single page first and see how the review process goes.
Note that, since I do not speak czech, I rely on the english present and simply revise and rewrite.