### PR TITLE
Localization: removed link to abandoned sakren/translator

### DIFF
--- a/cs/localization.texy
+++ b/cs/localization.texy
@@ -23,7 +23,7 @@ class MyTranslator implements Nette\Localization\ITranslator
 }
 \--
 
-Nette neobsahuje výchozí implementaci pro ITranslator. Můžeme ovšem sáhnout po hotových řešeních, jako je například [Kdyby Translation | https://github.com/kdyby/translation] nebo [Sakren Translator | https://github.com/sakren/nette-translator].
+Nette neobsahuje výchozí implementaci pro ITranslator. Můžeme ovšem sáhnout po hotových řešeních, jako je například [Kdyby Translation | https://github.com/kdyby/translation].
 
 
 Překlad formulářů

--- a/en/localization.texy
+++ b/en/localization.texy
@@ -25,7 +25,7 @@ class MyTranslator implements Nette\Localization\ITranslator
 }
 \--
 
-Nette doesn't provide default implementation of ITranslator. However, we can choose from various solutions, for example [Kdyby Translation | https://github.com/kdyby/translation] or [Sakren Translator | https://github.com/sakren/nette-translator].
+Nette doesn't provide default implementation of ITranslator. However, we can choose from various solutions, for example [Kdyby Translation | https://github.com/kdyby/translation].
 
 
 Form translation


### PR DESCRIPTION
Hi,

I just marked [sakren/nette-translator](https://github.com/davidkudera/nette-translator) as abandoned package, so it should be removed also from documentation.

There was a discussion at nette/web-content#179 about translators which should be added here. I'm really grateful that my package was chosen, even when I know that it was mainly because otherwise this list would look biased... 

So I'll ask you for the same thing like in that previous pull request:

"If you believe there are more ITranslator implementations that should be linked, please tell me."