### PR TITLE
Nette.org

### DIFF
--- a/pla/cs/jak-otevrit-soubor-z-debuggeru-v-editoru.texy
+++ b/pla/cs/jak-otevrit-soubor-z-debuggeru-v-editoru.texy
@@ -197,6 +197,7 @@ Troubleshooting:
 
 - ve Firefoxu může být potřeba protokol povolit pomocí network.protocol-handler.expose.editor nebo network.protocol-handler.expose-all v about:config. Ve výchozím nastavení je to ovšem povoleno :)
 - Pokud vám to hned nepůjde nepanikařte. A zkuste párkrát refreshnout stránku před klikem na onen odkaz. Rozjede se to!
+- V případě chyby. Input Error: There is no script engine for file extension ".js" **Maybe you associated ".js" file to another app, not JScript engine.** Zde je [link|http://www.winhelponline.com/articles/230/1/Error-There-is-no-script-engine-for-file-extension-when-running-js-files.html]  na opravu. 
 
 S případnými dotazy nebo připomínkami se prosím obraťte na [fórum | http://forum.nette.org/cs/5464-jak-nastavit-nette-debug-aby-oteviral-soubory-ve-vasem-editoru].
 

--- a/pla/en/how-open-files-in-ide-from-debugger.texy
+++ b/pla/en/how-open-files-in-ide-from-debugger.texy
@@ -161,6 +161,8 @@ Troubleshooting:
 
 - in Firefox you may need to allow custom protocol execution in about:config by setting *network.protocol-handler.expose.editor* or *network.protocol-handler.expose-all*. It should be allowed by default however.
 - If it's not all working immediately, don't panic. Try to refresh the page, restart browser or computer. That should help.
+- Input Error: There is no script engine for file extension ".js" **Maybe you associated ".js" file to another app, not JScript engine. To fix, see [here|http://www.winhelponline.com/articles/230/1/Error-There-is-no-script-engine-for-file-extension-when-running-js-files.html]**
+
 
 In case of more troubles or questions, ask on [forum | http://forum.nette.org/en].
 


### PR DESCRIPTION
V případě chyby. Input Error: There is no script engine for file extension ".js" pri otevirani souboru z Tracy link na opravu