### PR TITLE
Odstranění stránek prezidenta z referencí

### DIFF
--- a/cs/getting-started.texy
+++ b/cs/getting-started.texy
@@ -23,7 +23,7 @@ Proč právě Nette Framework?
 [* ecommercial.png .[noborder] >]
 Jak se Nette Framework liší od jiných frameworků? **Nette Framework je stavěný tak, aby byl co nejpoužitelnější a nejvstřícnější.** Jde o framework, s nímž je nejen snadné, ale i zábavné pracovat. Dává vám srozumitelnou a úspornou syntaxi, vychází vám vstříc při programování a debugování, nechává vás soustředit se na kreativní stránku vývoje a nepřidělává vám vrásky. Eliminuje bezpečnostní rizika. Můžete v něm tvořit e-shopy, wiki, blogy, CMS, co jen vymyslíte.
 
-Nette Framework [používají významné společnosti |www:who-uses-nette] jako třeba T-Systems, GE Money, Mladá fronta, VLTAVA-LABE-PRESS, Internet Info, DHL, Logio, ESET, Actum, Slevomat, Socialbakers, SUPRAPHON, pohání i stránky prezidenta republiky Václava Klause. V [anketě |https://spreadsheets.google.com/viewanalytics?formkey=dEl1ZDJhbk1hWEFLbU43Skl0eDVDSnc6MQ#chart#4] serveru Zdroják byl zvolen jako nepopulárnější a nejpoužívanější framework v České republice.
+Nette Framework [používají významné společnosti |www:who-uses-nette] jako třeba T-Systems, GE Money, Mladá fronta, VLTAVA-LABE-PRESS, Internet Info, DHL, Logio, ESET, Actum, Slevomat, Socialbakers a SUPRAPHON. V [anketě |https://spreadsheets.google.com/viewanalytics?formkey=dEl1ZDJhbk1hWEFLbU43Skl0eDVDSnc6MQ#chart#4] serveru Zdroják byl zvolen jako nepopulárnější a nejpoužívanější framework v České republice.
 
 Když se naučíte Nette Framework, nebudete mít nouzi o zajímavé pracovní nabídky.
 


### PR DESCRIPTION
Václav Klaus již není prezident ČR a tak je reference na jeho webové stránky nepravdivá.