### PR TITLE
Fix in example "how to set namespace for user storage"

### DIFF
--- a/cs/access-control.texy
+++ b/cs/access-control.texy
@@ -396,7 +396,7 @@ Pakliže používáme [presentery | presenters], nastavíme jmenný prostor ve s
 /--php
 public function checkRequirements($element)
 {
-	$this->getUser()->setNamespace('backend');
+	$this->getUser()->getStorage()->setNamespace('backend');
 	parent::checkRequirements($element);
 }
 \--

--- a/en/access-control.texy
+++ b/en/access-control.texy
@@ -381,7 +381,7 @@ When using [presenters], we will set the namespace in the common ancestor - usua
 /--php
 public function checkRequirements($element)
 {
-	$this->getUser()->setNamespace('backend');
+	$this->getUser()->getStorage()->setNamespace('backend');
 	parent::checkRequirements($element);
 }
 \--


### PR DESCRIPTION
`Nette\Security\User` doesn't have `setNamespace` method.