### PR TITLE
Typos.

### DIFF
--- a/cs/strings.texy
+++ b/cs/strings.texy
@@ -170,7 +170,7 @@ $isUtf8 = Strings::checkEncoding($string);
 \--
 
 
-*int* length($s)
+*int* length($s) .{toc: length()}
 ----------
 
 Vrací délku UTF-8 řetězce.

--- a/en/strings.texy
+++ b/en/strings.texy
@@ -169,7 +169,7 @@ $isUtf8 = Strings::checkEncoding($string);
 \--
 
 
-*int* length($s)
+*int* length($s) .{toc: length()}
 ----------
 
 Returns a length of a UTF-8 string.


### PR DESCRIPTION
Add missing method names for table of contents.