### PR TITLE
Added substitude for $defaultFlags

### DIFF
--- a/cs/routing.texy
+++ b/cs/routing.texy
@@ -324,7 +324,7 @@ Route::$defaultFlags = Route::SECURED;
 \--
 
 .[caution]
-Route::$defaultFlags v Nette 2.4 již nepodporovaté
+Route::$defaultFlags v Nette 2.4 již nepodporované
 
 Náhrada za `Route::$defaultFlags`
 ---------------------------------

--- a/cs/routing.texy
+++ b/cs/routing.texy
@@ -323,6 +323,27 @@ Pokud potřebujete do HTTPS překlopit celou aplikaci, použijte `Route::$defaul
 Route::$defaultFlags = Route::SECURED;
 \--
 
+.[caution]
+Route::$defaultFlags v Nette 2.4 již nepodporovaté
+
+Náhrada za `Route::$defaultFlags`
+---------------------------------
+
+Jestliže využíváme pouze HTTP nebo HTTPS, tak se již dále nemusíme o překlápění aplikace starat. Ovšem jestliže využíváme HTTP a HTTPS, a potřebovali bychom jinou aplikaci jako subdoménu, kterou ovšem potřebujeme celou překlopit do HTTPS, tak to můžeme provést jednoduchým zápisem do souboru v hlavním adresáři aplikaci .htaccess
+
+/--php
+<IfModule mod_rewrite.c>
+	RewriteEngine On
+	...
+	RewriteCond %{HTTPS} !=on
+	RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+	...
+</IfModule>
+\--
+
+R=301 nám zajistí kanonizaci.
+
+
 Transformace a překlady
 -----------------------
 

--- a/en/routing.texy
+++ b/en/routing.texy
@@ -395,12 +395,12 @@ Route::$defaultFlags |= Route::CASE_SENSITIVE;
 \--
 
 .[caution]
-Route::$defaultFlags at Nette 2.4 is deprecated
+Route::$defaultFlags is deprecated since Nette 2.4
 
 Substitude for `Route::$defaultFlags`
 ---------------------------------
 
-If we use HTTP or HTTPS only, so the longer have to worry a tipping application. Of course, if we use HTTP and HTTPS cuncurrently, and we need another for subdomain (for example), than we can do it by easy write to file in main directory of application .htaccess
+If we use only HTTP or only HTTPS, we no longer have to worry a about redirecting. If we need to use HTTP and HTTPS cuncurrently, we can do it in .htacess file in main directory of our application.
 
 /--php
 <IfModule mod_rewrite.c>
@@ -412,7 +412,7 @@ If we use HTTP or HTTPS only, so the longer have to worry a tipping application.
 </IfModule>
 \--
 
-R=301 we provide canonization.
+R=301 provides canonization.
 
 
 Filters and Translation

--- a/en/routing.texy
+++ b/en/routing.texy
@@ -394,6 +394,25 @@ Flags can be freely combined using bitwise OR operator (`|`) and it is possible 
 Route::$defaultFlags |= Route::CASE_SENSITIVE;
 \--
 
+.[caution]
+Route::$defaultFlags at Nette 2.4 is deprecated
+
+Substitude for `Route::$defaultFlags`
+---------------------------------
+
+If we use HTTP or HTTPS only, so the longer have to worry a tipping application. Of course, if we use HTTP and HTTPS cuncurrently, and we need another for subdomain (for example), than we can do it by easy write to file in main directory of application .htaccess
+
+/--php
+<IfModule mod_rewrite.c>
+	RewriteEngine On
+	...
+	RewriteCond %{HTTPS} !=on
+	RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+	...
+</IfModule>
+\--
+
+R=301 we provide canonization.
 
 
 Filters and Translation


### PR DESCRIPTION
Route::$defaultFlags is deprecated, so there is substitude for it.