### PR TITLE
cs/routing.texy, en/routing.texy fix to match examples

### DIFF
--- a/cs/routing.texy
+++ b/cs/routing.texy
@@ -148,8 +148,8 @@ Kolekce rout
 Protože rout budeme zpravidla definovat více než jednu, zabalíme je do [RouteList | api:Nette\Application\Routers\RouteList]. A opět rovnou ukázka použítí v souboru [bootstrap.php |presenters#index-php-bootstrap-php]: (`$container` je [systémový DI kontejner |configuring])
 
 /--php
-use Nette\Application\Routers\RouteList,
-	Nette\Application\Routers\Route;
+use Nette\Application\Routers\RouteList;
+use Nette\Application\Routers\Route;
 
 $router = new RouteList;
 $router[] = new Route('article/<id>', 'Article:view');
@@ -482,11 +482,21 @@ Vlastní router
 Pokud vám nabízené routery nedostačují, můžete si vytvořit router vlastní a zcela přirozeně ho začlenit do kolekce rout. Router je implementací rozhraní [IRouter | api:Nette\Application\IRouter] se dvěma metodami:
 
 /-- php
+use Nette\Application\Request as AppRequest;
+use Nette\Http\IRequest as HttpRequest;
+use Nette\Http\Url;
+
 class MyRouter implements Nette\Application\IRouter
 {
-	function match(Nette\Http\IRequest $httpRequest){ }
+	function match(HttpRequest $httpRequest)
+	{
+		// ...
+	}
 
-	function constructUrl(Nette\Application\Request $appRequest, Nette\Http\Url $refUrl) { }
+	function constructUrl(AppRequest $appRequest, Url $refUrl)
+	{
+		// ...
+	}
 }
 \--
 

--- a/en/routing.texy
+++ b/en/routing.texy
@@ -156,8 +156,8 @@ Route Collection
 Because we usually define more than one route, we wrap them into a [RouteList | api:Nette\Application\Routers\RouteList].
 
 /--php
-use Nette\Application\Routers\RouteList,
-	Nette\Application\Routers\Route;
+use Nette\Application\Routers\RouteList;
+use Nette\Application\Routers\Route;
 
 $router = new RouteList();
 $router[] = new Route('rss.xml', 'Feed:rss');
@@ -589,9 +589,9 @@ Custom Router
 If these offered routes do not fit your needs, you may create your own router and add it to your *router collection*. Router is nothing more than an implementation of [IRouter | api:Nette\Application\IRouter] with it's two methods:
 
 /--php
-use Nette\Application\Request as AppRequest,
-	Nette\Http\IRequest as HttpRequest,
-	Nette\Http\Url;
+use Nette\Application\Request as AppRequest;
+use Nette\Http\IRequest as HttpRequest;
+use Nette\Http\Url;
 
 class MyRouter implements Nette\Application\IRouter
 {


### PR DESCRIPTION
Fix Use-statment to newer coding standard in examples
Updated last example "Custom router" in CS translation to match newer version from EN translation in en/routing.texy