### PR TITLE
Latte: links in default macros

### DIFF
--- a/latte/cs/macros.texy
+++ b/latte/cs/macros.texy
@@ -1,4 +1,4 @@
-﻿Výchozí Latte makra
+Výchozí Latte makra
 *******************
 
 .[perex]

--- a/latte/cs/macros.texy
+++ b/latte/cs/macros.texy
@@ -1,4 +1,4 @@
-Výchozí Latte makra
+﻿Výchozí Latte makra
 *******************
 
 .[perex]
@@ -9,42 +9,42 @@ Zajímají vás bližší informace o [syntaxi Latte |homepage] nebo o [výchoz�
 .[wide]
 | Výpis proměnných a výrazů ||
 |---------------------------
-| `{$variable}`                  | [vypíše escapovanou proměnnou |#Vypsání proměnné]
-| `{$variable\|noescape}`        | [vypíše proměnnou bez escapování |#Vypsání proměnné]
-| `{expression}`                 | [vypíše escapovaný výraz |#Vypsání proměnné]
-| `{expression\|noescape}`       | [vypíše výraz bez escapování |#Vypsání proměnné]
+| `{$variable}`                  | [vypíše escapovanou proměnnou |#vypsani-promenne-nebo-vyrazu-expression]
+| `{$variable\|noescape}`        | [vypíše proměnnou bez escapování |#vypsani-promenne-nebo-vyrazu-expression]
+| `{expression}`                 | [vypíše escapovaný výraz |#vypsani-promenne-nebo-vyrazu-expression]
+| `{expression\|noescape}`       | [vypíše výraz bez escapování |#vypsani-promenne-nebo-vyrazu-expression]
 |---------------------------
 | Podmínky ||
 |---------------------------
-| `{if $cond} … {elseif $cond} … {else} … {/if}`  [podmínka if |#Podmínky] ||
-| `{$cond ? $value1 : $value2}`|[ternární operátor |#Podmínky] |
-| `{$cond ? $value}`|[zkrácený "ternární" operátor |#Podmínky] |
-| `{ifset $var} … {elseifset $var} … {/ifset}`  [podmínka if (isset()) |#Podmínky] ||
+| `{if $cond} … {elseif $cond} … {else} … {/if}`  [podmínka if |#podminky-if-cond-if-cond] ||
+| `{$cond ? $value1 : $value2}`|[ternární operátor |#podminky-if-cond-if-cond] |
+| `{$cond ? $value}`|[zkrácený "ternární" operátor |#podminky-if-cond-if-cond] |
+| `{ifset $var} … {elseifset $var} … {/ifset}`  [podmínka if (isset()) |#podminky-if-cond-if-cond] ||
 |---------------------------
 | Cykly ||
 |---------------------------
-| `{foreach $arr as $item} … {/foreach}` | [cyklus foreach |#Cykly]
-| `{for expr; expr; expr} … {/for}`      | [cyklus for |#Cykly]
-| `{while expr} … {/while}`              | [cyklus while |#Cykly]
-| `{continueIf $cond}`                   | [podmíněný skok na další iteraci |#Cykly]
-| `{breakIf $cond}`                      | [podmíněné ukončení cyklu |#Cykly]
-| `{first [$mod]} … {/first}`            | [vypsat při prvním průchodu |#Cykly]
-| `{last [$mod]} … {/last}`              | [vypsat při posledním průchodu |#Cykly]
-| `{sep} … {/sep}`                       | [separátor |#Cykly]
+| `{foreach $arr as $item} … {/foreach}` | [cyklus foreach |#cykly-foreach-for-while]
+| `{for expr; expr; expr} … {/for}`      | [cyklus for |#cykly-foreach-for-while]
+| `{while expr} … {/while}`              | [cyklus while |#cykly-foreach-for-while]
+| `{continueIf $cond}`                   | [podmíněný skok na další iteraci |#cykly-foreach-for-while]
+| `{breakIf $cond}`                      | [podmíněné ukončení cyklu |#cykly-foreach-for-while]
+| `{first [$mod]} … {/first}`            | [vypsat při prvním průchodu |#cykly-foreach-for-while]
+| `{last [$mod]} … {/last}`              | [vypsat při posledním průchodu |#cykly-foreach-for-while]
+| `{sep} … {/sep}`                       | [separátor |#cykly-foreach-for-while]
 |---------------------------
 | Proměnné ||
 |---------------------------
-| `{var $foo = value}`           | [vytvoří proměnnou |#Deklarace proměnných]
-| `{default $foo = value}`       | [výchozí proměnnou pokud neexistuje |#Deklarace proměnných]
-| `{capture $var} … {/capture}`  | [zachytí blok do proměnné |#Zachytávání do proměnné]
+| `{var $foo = value}`           | [vytvoří proměnnou |#deklarace-promennych-var-a-default]
+| `{default $foo = value}`       | [výchozí proměnnou pokud neexistuje |#deklarace-promennych-var-a-default]
+| `{capture $var} … {/capture}`  | [zachytí blok do proměnné |#zachytavani-do-promenne-capture]
 |---------------------------
 | Systémové ||
 |---------------------------
-| `{include 'file.latte'}`       | [načte šablonu z dalšího souboru |#Vložení souboru]
+| `{include 'file.latte'}`       | [načte šablonu z dalšího souboru |#vlozeni-souboru-include]
 | `{cache $key} … {/cache}`      | [cachuje část šablony |doc:caching#cachovani-v-sablonach]
-| `{php expression}`             | [vyhodnotí výraz, ale nevypíše |#Vyhodnocení kódu]
+| `{php expression}`             | [vyhodnotí výraz, ale nevypíše |#vyhodnoceni-kodu-php-expression]
 | `{* text komentáře *}`         | komentář, bude odstraněn
-| `{syntax mode}`                | [změna syntaxe maker za běhu |#Změna syntaxe]
+| `{syntax mode}`                | [změna syntaxe maker za běhu |#zmena-syntaxe-syntax]
 | `{use Class}`                  | načte nová makra
 | `{l}` nebo `{r}`               | vypíše znak { nebo }
 | `{contentType $type}`          | [přepne escapování a pošle HTTP hlavičku |#hlavicka-contenttype]
@@ -59,18 +59,18 @@ Zajímají vás bližší informace o [syntaxi Latte |homepage] nebo o [výchoz�
 |---------------------------
 | Překlady ||
 |---------------------------
-| `{_}Text{/_}`                  | [přeloží text |#Překlady]
-| `{_expression}`                | [přeloží výraz a vypíše s escapováním |#Překlady]
+| `{_}Text{/_}`                  | [přeloží text |#preklady-expression]
+| `{_expression}`                | [přeloží výraz a vypíše s escapováním |#preklady-expression]
 |---------------------------
 | Bloky, layouty, dědičnost šablon ||
 |---------------------------
-| `{block block}`                | [definuje a hned vykreslí blok |#bloky]
-| `{define block}`               | [definuje blok pro pozdější použití |#bloky]
-| `{include block}`              | [vloží blok |#Vkládání bloků]
+| `{block block}`                | [definuje a hned vykreslí blok |#bloky-block-a-define]
+| `{define block}`               | [definuje blok pro pozdější použití |#bloky-block-a-define]
+| `{include block}`              | [vloží blok |#vkladani-bloku-include-block]
 | `{includeblock 'file.latte'}`  | načte bloky z externí šablony
-| `{layout 'file.latte'}`        | [určuje soubor s layoutem |#rozšiřování a dědičnost]
-| `{extends 'file.latte'}`       | [alias pro `{layout}` |#rozšiřování a dědičnost]
-| `{ifset #block} … {/ifset}`    | [podmínka, zda existuje blok |#bloky]
+| `{layout 'file.latte'}`        | [určuje soubor s layoutem |#rozsirovani-a-dedicnost-sablon-layout]
+| `{extends 'file.latte'}`       | [alias pro `{layout}` |#rozsirovani-a-dedicnost-sablon-layout]
+| `{ifset #block} … {/ifset}`    | [podmínka, zda existuje blok |#bloky-block-a-define]
 |---------------------------
 | Odkazy ||
 |---------------------------
@@ -81,12 +81,12 @@ Zajímají vás bližší informace o [syntaxi Latte |homepage] nebo o [výchoz�
 |---------------------------
 | Ovládací prvky a formuláře ||
 |---------------------------
-| `{control loginForm}`          | [vykreslí komponentu |#Vykreslování komponent]
-| `{form formName} … {/form}`    | [vykreslí značky formuláře |#formuláře]
-| `{label fieldName} … {/label}` | [vykreslí popisku formulářového prvku |#formuláře]
-| `{input fieldName}`            | [vykreslí formulářový prvek |#formuláře]
-| `{inputError fieldName}`       | [vypíše chybovou hlášku formulářového prvku |#formuláře]
-| `n:name`                       | [oživí formulářový prvek |#formuláře]
+| `{control loginForm}`          | [vykreslí komponentu |#vykreslovani-komponent-control]
+| `{form formName} … {/form}`    | [vykreslí značky formuláře |#formulare-form-input-inputerror-label]
+| `{label fieldName} … {/label}` | [vykreslí popisku formulářového prvku |#formulare-form-input-inputerror-label]
+| `{input fieldName}`            | [vykreslí formulářový prvek |#formulare-form-input-inputerror-label]
+| `{inputError fieldName}`       | [vypíše chybovou hlášku formulářového prvku |#formulare-form-input-inputerror-label]
+| `n:name`                       | [oživí formulářový prvek |#formulare-form-input-inputerror-label]
 |---------------------------
 | AJAX ||
 |---------------------------
@@ -94,8 +94,8 @@ Zajímají vás bližší informace o [syntaxi Latte |homepage] nebo o [výchoz�
 |---------------------------
 | Ladění ||
 |---------------------------
-| `{dump $variable}`             | [dumpuje proměnné do Debugger Bar |#Dumpování proměnných]
-| `{debugbreak $cond}`           | [umístí do kódu breakpoint |#debugbreak]
+| `{dump $variable}`             | [dumpuje proměnné do Debugger Bar |#dumpovani-promennych-dump]
+| `{debugbreak $cond}`           | [umístí do kódu breakpoint |#break-point-debugbreak]
 
 
 

--- a/latte/en/macros.texy
+++ b/latte/en/macros.texy
@@ -1,4 +1,4 @@
-Default Latte Macros
+﻿Default Latte Macros
 ********************
 
 .[perex]
@@ -9,40 +9,40 @@ Are you interested in taking a closer look at [Latte syntax |templating#latte]?
 .[wide]
 | Variable and expression printing ||
 |---------------------------
-| `{$variable}`                  | [prints an escaped variable |#Variable printing]
-| `{$variable\|noescape}`        | [prints a variable without escaping |#Variable printing]
-| `{expression}`                 | [prints an escaped expression |#Variable printing]
-| `{expression\|noescape}`       | [prints an expression without escaping |#Variable printing]
+| `{$variable}`                  | [prints an escaped variable |#variable-and-expression-printing-expression]
+| `{$variable\|noescape}`        | [prints a variable without escaping |#variable-and-expression-printing-expression]
+| `{expression}`                 | [prints an escaped expression |#variable-and-expression-printing-expression]
+| `{expression\|noescape}`       | [prints an expression without escaping |#variable-and-expression-printing-expression]
 |---------------------------
 | Conditions ||
 |---------------------------
-| `{if $cond} … {elseif $cond} … {else} … {/if}`  [if condition |#Conditions] ||
-| `{ifset $var} … {elseifset $var} … {/ifset}`  [if (isset()) condition |#Conditions] ||
+| `{if $cond} … {elseif $cond} … {else} … {/if}`  [if condition |#conditions-if-cond-if] ||
+| `{ifset $var} … {elseifset $var} … {/ifset}`  [if (isset()) condition |#conditions-if-cond-if] ||
 |---------------------------
 | Loops ||
 |---------------------------
-| `{foreach $arr as $item} … {/foreach}` | [foreach loop |#Loops]
-| `{for expr; expr; expr} … {/for}`      | [for loop |#Loops]
-| `{while expr} … {/while}`      | [while loop |#Loops]
-| `{continueIf $cond}`           | [conditional jump to the next iteration |#Loops]
-| `{breakIf $cond}`              | [conditional loop break |#Loops]
-| `{first} … {/first}`           | [prints if first iteration |#Loops]
-| `{last} … {/last}`             | [prints if last iteration |#Loops]
-| `{sep} … {/sep}`               | [separator |#Loops]
+| `{foreach $arr as $item} … {/foreach}` | [foreach loop |#loops-foreach-for-while]
+| `{for expr; expr; expr} … {/for}`      | [for loop |#loops-foreach-for-while]
+| `{while expr} … {/while}`      | [while loop |#loops-foreach-for-while]
+| `{continueIf $cond}`           | [conditional jump to the next iteration |#loops-foreach-for-while]
+| `{breakIf $cond}`              | [conditional loop break |#loops-foreach-for-while]
+| `{first} … {/first}`           | [prints if first iteration |#loops-foreach-for-while]
+| `{last} … {/last}`             | [prints if last iteration |#loops-foreach-for-while]
+| `{sep} … {/sep}`               | [separator |#loops-foreach-for-while]
 |---------------------------
 | Variables ||
 |---------------------------
-| `{var $foo = value}`           | [variable creation |#Variable declaration]
-| `{default $foo = value}`       | [default value when variable isn't declared |#Variable declaration]
-| `{capture $var} … {/capture}`  | [captures a section to a variable |#Capturing to variables]
+| `{var $foo = value}`           | [variable creation |#variable-declaration-var-and-default]
+| `{default $foo = value}`       | [default value when variable isn't declared |#variable-declaration-var-and-default]
+| `{capture $var} … {/capture}`  | [captures a section to a variable |#capturing-to-variables-capture]
 |---------------------------
 | Engine ||
 |---------------------------
-| `{include 'file.latte'}`       | [includes a template from other file |#File including]
+| `{include 'file.latte'}`       | [includes a template from other file |#file-including-include]
 | `{cache $key} … {/cache}`      | [caches a template section |doc:caching#caching-in-templates]
-| `{php expression}`             | [evaluates an expression without printing it |#Code evaluation]
+| `{php expression}`             | [evaluates an expression without printing it |#code-evaluation-php-expression]
 | `{* comment text *}`           | a comment (removed from evaluation)
-| `{syntax mode}`                | [switches the syntax at runtime |#Syntax switching]
+| `{syntax mode}`                | [switches the syntax at runtime |#syntax-switching-syntax]
 | `{use Class}`                  | loads new user-defined macros
 | `{l}` or `{r}`                 | prints { and } characters, respectively
 | `{contentType $type}`          | [switches the escaping mode and sends HTTP header |#header-contenttype]
@@ -57,19 +57,19 @@ Are you interested in taking a closer look at [Latte syntax |templating#latte]?
 |---------------------------
 | Translations ||
 |---------------------------
-| `{_}Text{/_}`                  | [translates a text |#Localization]
-| `{_expression}`                | [translates an expression and prints it with escaping |#Localization]
+| `{_}Text{/_}`                  | [translates a text |#localization-expression]
+| `{_expression}`                | [translates an expression and prints it with escaping |#localization-expression]
 |---------------------------
 | Blocks, layouts, template inheritance ||
 |---------------------------
-| `{block block}`                | [block definition and immediate print out |#blocks]
-| `{define block}`               | [block defintion for future use |#blocks]
-| `{include block}`              | [inserts a block |#block including]
-| `{include mytemplate.latte}`   | [inserts a template |#block including]
-| `{includeblock 'file.latte'}`  | [loads blocks from external template |#template expanding/inheritance]
-| `{layout 'file.latte'}`        | [specifies a layout file |#template expanding/inheritance]
-| `{extends 'file.latte'}`       | [alias for `{layout}` |#template expanding/inheritance]
-| `{ifset #block} … {/ifset}`    | [condition if block is defined |#blocks]
+| `{block block}`                | [block definition and immediate print out |#blocks-block-and-define]
+| `{define block}`               | [block defintion for future use |#blocks-block-and-define]
+| `{include block}`              | [inserts a block |#block-and-template-inclusion-include-block-or-include-mytemplate-latte]
+| `{include mytemplate.latte}`   | [inserts a template |#block-and-template-inclusion-include-block-or-include-mytemplate-latte]
+| `{includeblock 'file.latte'}`  | [loads blocks from external template |#template-expansion-inheritance-layout]
+| `{layout 'file.latte'}`        | [specifies a layout file |#template-expansion-inheritance-layout]
+| `{extends 'file.latte'}`       | [alias for `{layout}` |#template-expansion-inheritance-layout]
+| `{ifset #block} … {/ifset}`    | [condition if block is defined |#blocks-block-and-define]
 |---------------------------
 | Links ||
 |---------------------------
@@ -80,12 +80,12 @@ Are you interested in taking a closer look at [Latte syntax |templating#latte]?
 |---------------------------
 | Controls and forms ||
 |---------------------------
-| `{control loginForm}`          | [prints a component |#Component rendering]
-| `{form formName} … {/form}`    | [prints a form element |#forms]
-| `{label fieldName} … {/label}` | [prints a form input label |#forms]
-| `{input fieldName}`            | [prints a form input element |#forms]
-| `{inputError fieldName}`       | [prints error message for form input element|#forms]
-| `n:name`                       | [activates an HTML input element |#forms]
+| `{control loginForm}`          | [prints a component |#component-rendering-control]
+| `{form formName} … {/form}`    | [prints a form element |#forms-form-input-inputerror-label]
+| `{label fieldName} … {/label}` | [prints a form input label |#forms-form-input-inputerror-label]
+| `{input fieldName}`            | [prints a form input element |#forms-form-input-inputerror-label]
+| `{inputError fieldName}`       | [prints error message for form input element|#forms-form-input-inputerror-label]
+| `n:name`                       | [activates an HTML input element |#forms-form-input-inputerror-label]
 |---------------------------
 | AJAX ||
 |---------------------------
@@ -93,8 +93,8 @@ Are you interested in taking a closer look at [Latte syntax |templating#latte]?
 |---------------------------
 | Debugging ||
 |---------------------------
-| `{dump $variable}`             | [dumps variables to the Debugger Bar |#Variable dumping]
-| `{debugbreak $cond}`           | [sets breakpoint to the code |#debugbreak]
+| `{dump $variable}`             | [dumps variables to the Debugger Bar |#variable-dumping-dump]
+| `{debugbreak $cond}`           | [sets breakpoint to the code |#break-point-debugbreak]
 
 
 

--- a/latte/en/macros.texy
+++ b/latte/en/macros.texy
@@ -1,4 +1,4 @@
-﻿Default Latte Macros
+Default Latte Macros
 ********************
 
 .[perex]


### PR DESCRIPTION
Currently when you open Latte documentation page for [Default Latte Macros](https://latte.nette.org/en/macros) it is not possible go from links in table with macros to the selected content below the table. This pull request fixes that in Czech and English version of documentation.