### PR TITLE
Latte: include block depreciation

### DIFF
--- a/latte/cs/macros.texy
+++ b/latte/cs/macros.texy
@@ -1,4 +1,4 @@
-﻿Výchozí Latte makra
+Výchozí Latte makra
 *******************
 
 .[perex]

--- a/latte/cs/macros.texy
+++ b/latte/cs/macros.texy
@@ -1,4 +1,4 @@
-Výchozí Latte makra
+﻿Výchozí Latte makra
 *******************
 
 .[perex]
@@ -67,7 +67,7 @@ Zajímají vás bližší informace o [syntaxi Latte |homepage] nebo o [výchoz�
 | `{block block}`                | [definuje a hned vykreslí blok |#bloky]
 | `{define block}`               | [definuje blok pro pozdější použití |#bloky]
 | `{include block}`              | [vloží blok |#Vkládání bloků]
-| `{includeblock 'file.latte'}`  | načte bloky z externí šablony
+| `{import 'file.latte'}`  | načte bloky z externí šablony
 | `{layout 'file.latte'}`        | [určuje soubor s layoutem |#rozšiřování a dědičnost]
 | `{extends 'file.latte'}`       | [alias pro `{layout}` |#rozšiřování a dědičnost]
 | `{ifset #block} … {/ifset}`    | [podmínka, zda existuje blok |#bloky]

--- a/latte/cs/macros.texy
+++ b/latte/cs/macros.texy
@@ -67,7 +67,7 @@ Zajímají vás bližší informace o [syntaxi Latte |homepage] nebo o [výchoz�
 | `{block block}`                | [definuje a hned vykreslí blok |#bloky]
 | `{define block}`               | [definuje blok pro pozdější použití |#bloky]
 | `{include block}`              | [vloží blok |#Vkládání bloků]
-| `{import 'file.latte'}`  | načte bloky z externí šablony
+| `{import 'file.latte'}`        | načte bloky z externí šablony
 | `{layout 'file.latte'}`        | [určuje soubor s layoutem |#rozšiřování a dědičnost]
 | `{extends 'file.latte'}`       | [alias pro `{layout}` |#rozšiřování a dědičnost]
 | `{ifset #block} … {/ifset}`    | [podmínka, zda existuje blok |#bloky]

--- a/latte/en/macros.texy
+++ b/latte/en/macros.texy
@@ -1,4 +1,4 @@
-Default Latte Macros
+﻿Default Latte Macros
 ********************
 
 .[perex]
@@ -66,7 +66,7 @@ Are you interested in taking a closer look at [Latte syntax |templating#latte]?
 | `{define block}`               | [block defintion for future use |#blocks]
 | `{include block}`              | [inserts a block |#block including]
 | `{include mytemplate.latte}`   | [inserts a template |#block including]
-| `{includeblock 'file.latte'}`  | [loads blocks from external template |#template expanding/inheritance]
+| `{import 'file.latte'}`  | [loads blocks from external template |#template expanding/inheritance]
 | `{layout 'file.latte'}`        | [specifies a layout file |#template expanding/inheritance]
 | `{extends 'file.latte'}`       | [alias for `{layout}` |#template expanding/inheritance]
 | `{ifset #block} … {/ifset}`    | [condition if block is defined |#blocks]

--- a/latte/en/macros.texy
+++ b/latte/en/macros.texy
@@ -1,4 +1,4 @@
-﻿Default Latte Macros
+Default Latte Macros
 ********************
 
 .[perex]

--- a/latte/en/macros.texy
+++ b/latte/en/macros.texy
@@ -66,7 +66,7 @@ Are you interested in taking a closer look at [Latte syntax |templating#latte]?
 | `{define block}`               | [block defintion for future use |#blocks]
 | `{include block}`              | [inserts a block |#block including]
 | `{include mytemplate.latte}`   | [inserts a template |#block including]
-| `{import 'file.latte'}`  | [loads blocks from external template |#template expanding/inheritance]
+| `{import 'file.latte'}`        | [loads blocks from external template |#template expanding/inheritance]
 | `{layout 'file.latte'}`        | [specifies a layout file |#template expanding/inheritance]
 | `{extends 'file.latte'}`       | [alias for `{layout}` |#template expanding/inheritance]
 | `{ifset #block} … {/ifset}`    | [condition if block is defined |#blocks]


### PR DESCRIPTION
Macro {includeblock} is [depreciated](https://forum.nette.org/cs/26250-pojdte-otestovat-nette-2-4-rc). Maybe it will be better have in documentation macro {import} instead that.