### PR TITLE
Tracy requires 'self' in CSP since 2.4

### DIFF
--- a/tracy/cs/homepage.texy
+++ b/tracy/cs/homepage.texy
@@ -161,7 +161,7 @@ Alternativně je také možné toto nastavit v konfiguračním souboru:
 
 Aby vám však nezaplavila e-mailovou schránku, pošle vždy **pouze jednu zprávu** a vytvoří soubor `email-sent`. Vývojář po přijetí e-mailové notifikace zkontroluje log, opraví aplikaci a smaže monitorovací soubor, čímž se opět aktivuje odesílání e-mailů.
 
-Pokud vaše aplikace používá Content Security Policy, budete muset přidat `'unsafe-inline'` do `style-src` a `'unsafe-inline'` & `'unsafe-eval'` do `script-src`, jinak Tracy nebude správně fungovat. V produkčním režimu tyto hodnoty nepřidávejte, pokud nemusíte. .[note]
+Pokud vaše aplikace používá Content Security Policy, budete muset přidat `'unsafe-inline'` do `style-src` a `'unsafe-inline'`, `'unsafe-eval'` & `'self'` (nebo patřičný "origin") do `script-src`, jinak Tracy nebude správně fungovat. V produkčním režimu `'unsafe-inline'` & `'unsafe-eval'` nepřidávejte, pokud nemusíte. .[note]
 
 
 Dump proměnných

--- a/tracy/en/homepage.texy
+++ b/tracy/en/homepage.texy
@@ -149,7 +149,7 @@ Debugger::$email = 'admin@example.com';
 
 To protect your e-mail box from flood, Tracy sends **only one message** and creates a file `email-sent`. When a developer receives the e-mail notification, he checks the log, corrects his application and deletes the `email-sent` monitoring file. This activates the e-mail sending again.
 
-If your site uses Content Security Policy, you'll need to add `'unsafe-inline'` to `style-src`, and `'unsafe-inline'` & `'unsafe-eval'` to `script-src` for Tracy to work properly. Avoid adding these in production mode, if you can. .[note]
+If your site uses Content Security Policy, you'll need to add `'unsafe-inline'` to `style-src`, and `'unsafe-inline'`, `'unsafe-eval'` & `'self'` (or equivalent origin) to `script-src` for Tracy to work properly. Avoid adding `'unsafe-inline'` & `'unsafe-eval'` in production mode, if you can. .[note]
 
 
 Variable dumping


### PR DESCRIPTION
Required since https://github.com/nette/tracy/commit/13f854d4c11221add4697121e183a147732bb13b

Content Security Policy nonce (see https://github.com/nette/tracy/issues/136) is the future but now this doc update should do.

Thanks!
