### PR TITLE
clarification of passing arguments to render()

### DIFF
--- a/cs/components.texy
+++ b/cs/components.texy
@@ -45,7 +45,7 @@ public function render()
 }
 \--
 
-Ze šablony můžete komponentě i předat parametry - její metodě `render()`.
+Ze šablony můžeme komponentě i předat parametry. Ty se předají až metodě `render()`.
 /--latte
 {control poll $poll}
 \--


### PR DESCRIPTION
From the original description it wasn't obvious that the render method gets the parameters, not the Presenter method.