### PR TITLE
Tester: fix typo in --setup option (outputHandlers)

### DIFF
--- a/tester/cs/homepage.texy
+++ b/tester/cs/homepage.texy
@@ -972,7 +972,7 @@ Tester při startu načte zadaný PHP skript. V něm je k dispozici proměnná `
 
 
 /--php
-$runner->outputHandler[] = new MyOutputHandler;
+$runner->outputHandlers[] = new MyOutputHandler;
 \--
 
 a Tester spustíme:

--- a/tester/en/homepage.texy
+++ b/tester/en/homepage.texy
@@ -985,7 +985,7 @@ Core, ctype, date, dom, ereg, fileinfo, filter, hash, ...
 The Tester loads given PHP script on start. Variable `Tester\Runner\Runner $runner` is available in it. Let's assume file `tests/runner-setup.php`:
 
 /--php
-$runner->outputHandler[] = new MyOutputHandler;
+$runner->outputHandlers[] = new MyOutputHandler;
 \--
 
 and we run the Tester:


### PR DESCRIPTION
see `\Tester\Runner\Runner::$outputHandlers`