### PR TITLE
Fix typo in custom macro registration text (cs)

### DIFF
--- a/cs/configuring.texy
+++ b/cs/configuring.texy
@@ -233,7 +233,7 @@ V konfiguračním souboru lze změnit výchozí chybové hlášky.
 Šablony Latte
 -------------
 
-Lze přepínat HTML a XHTML režim šablon a registrovat vlastní Latte makra. Vlastní makra mohou být zaregistrována buď pomocí jména třídy nebo pomocí reference na šlužbu. Jako výchozí je zavolána metoda `install`, ale to můžete změnit tím, že přidáte dvojtečku a jméno vaší metody.
+Lze přepínat HTML a XHTML režim šablon a registrovat vlastní Latte makra. Vlastní makra mohou být zaregistrována buď pomocí jména třídy nebo pomocí reference na službu. Jako výchozí je zavolána metoda `install`, ale to můžete změnit tím, že přidáte dvojtečku a jméno vaší metody.
 
 /--neon
 	latte:


### PR DESCRIPTION
I am sorry I didn't notice this misspell before...

See related commit dce61b8